### PR TITLE
Updates MetaCert link, removes non-free Web of Trust

### DIFF
--- a/README.md
+++ b/README.md
@@ -98,9 +98,8 @@ For information on contributing to this project, please see the [contributing gu
 | :----------------------------------------------------------------------: | ---------------------------- | :------: | :---: | :-----: |
 |                 [AbuseIPDB](https://docs.abuseipdb.com/)                 | IP/domain/URL reputation     | `apiKey` |  Yes  | Unknown |
 |   [Google Safe Browsing](https://developers.google.com/safe-browsing/)   | Google Link/Domain Flagging  | `apiKey` |  Yes  | Unknown |
-|                    [Metacert](https://metacert.com/)                     | Metacert Link Flagging       | `apiKey` |  Yes  | Unknown |
+|                    [Metacert](https://developer.metacert.com/)           | Metacert Link Flagging       | `apiKey` |  Yes  | Unknown |
 |  [VirusTotal](https://www.virustotal.com/en/documentation/public-api/)   | VirusTotal File/URL Analysis | `apiKey` |  Yes  | Unknown |
-|            [Web Of Trust (WOT)](https://www.mywot.com/en/API)            | Website reputation           | `apiKey` |  Yes  | Unknown |
 
 **[⬆ Back to Index](#index)**
 


### PR DESCRIPTION
Thank you for taking the time to work on a Pull Request for this project!

To ensure your PR is dealt with swiftly please check the following:

- [X] Your submissions are formatted according to the guidelines in the [contributing guide](CONTRIBUTING.md)
- [X] Your additions are ordered alphabetically
- [X] Your submission has a useful description
- [X] The description does not end with punctuation
- [X] Each table column should be padded with one space on either side
- [X] You have searched the repository for any relevant issues or pull requests
- [X] Any category you are creating has the minimum requirement of 3 items
- [X] All changes have been [squashed][squash-link] into a single commit

[squash-link]: <https://github.com/todotxt/todo.txt-android/wiki/Squash-All-Commits-Related-to-a-Single-Issue-into-a-Single-Commit>

---

Hello,
This PR is just a small update to the Anti-Malware section:
- Web of Trust is no longer free to use <sup>See- [WoT Pricing](https://www.mywot.com/developers)</sup>
- Updated MetaCert link, as there is no link to their API from their homepage

Thank you for all the work you do maintaining this awesome list :)