### PR TITLE
Added Football-Standings-API

### DIFF
--- a/README.md
+++ b/README.md
@@ -918,6 +918,7 @@ For information on contributing to this project, please see the [contributing gu
 |       [Football (Soccer) Videos](https://www.scorebat.com/video-api/)        | Embed codes for goals and highlights from Premier League, Bundesliga, Serie A and many more |       No        |  Yes  |   Yes   |
 |         [Football Prediction](https://boggio-analytics.com/fp-api/)          | Predictions for upcoming football matches, odds, results and stats                          | `X-Mashape-Key` |  Yes  | Unknown |
 |           [Football-Data.org](http://api.football-data.org/index)            | Football Data                                                                               |       No        |  No   | Unknown |
+|    [Football-Standings-Api](https://api-football-standings.azharimm.dev/)    | Display football standings e.g epl, la liga, serie a etc                                   |       No        |  Yes  |   Unknown   |
 |               [JCDecaux Bike](https://developer.jcdecaux.com/)               | JCDecaux's self-service bicycles                                                            |    `apiKey`     |  Yes  | Unknown |
 |    [NBA Stats](https://any-api.com/nba_com/nba_com/docs/API_Description)     | Current and historical NBA Statistics                                                       |       No        |  Yes  | Unknown |
 |          [NHL Records and Stats](https://gitlab.com/dword4/nhlapi)           | NHL historical data and statistics                                                          |       No        |  Yes  | Unknown |


### PR DESCRIPTION
Added Azharimm's Football-Standings-API that Displays football standings e.g epl, la liga, serie a etc. The data is based on espn site

Thank you for taking the time to work on a Pull Request for this project!

To ensure your PR is dealt with swiftly please check the following:

- [x] Your submissions are formatted according to the guidelines in the [contributing guide](CONTRIBUTING.md)
- [x] Your additions are ordered alphabetically
- [x] Your submission has a useful description
- [x] The description does not end with punctuation
- [x] Each table column should be padded with one space on either side
- [x] You have searched the repository for any relevant issues or pull requests
- [x] Any category you are creating has the minimum requirement of 3 items
- [x] All changes have been [squashed][squash-link] into a single commit

[squash-link]: <https://github.com/todotxt/todo.txt-android/wiki/Squash-All-Commits-Related-to-a-Single-Issue-into-a-Single-Commit>
