### PR TITLE
Add TimeZones iCal Library to Calendar

### DIFF
--- a/README.md
+++ b/README.md
@@ -183,6 +183,7 @@ For information on contributing to this project, please see the [contributing gu
 |                  [Namedays Calendar](https://api.abalin.net/)                   | Provides namedays for multiple countries                                                               |    No    |  Yes  |   Yes   |
 |               [Non-Working Days](https://github.com/gadael/icsdb)               | Database of ICS files for non working days                                                             |    No    |  Yes  | Unknown |
 |            [Russian Calendar](https://github.com/egno/work-calendar)            | Check if a date is a Russian holiday or not                                                            |    No    |  Yes  |   No    |
+|       [TimeZones iCal Library](https://tz.add-to-calendar-technology.com/)      | Database of official time zones and corresponding iCal VTIMEZONE blocks                                |    No    |  Yes  | Unknown |
 
 **[⬆ Back to Index](#index)**
 


### PR DESCRIPTION
The TimeZones iCal Library holds API endpoints to GET a list of IANA time zones; and can also GET corresponding ical VTIMEZONE blocks as ics file response to include in any .ica iCal file

- [x] Your submissions are formatted according to the guidelines in the [contributing guide](CONTRIBUTING.md)
- [x] Your additions are ordered alphabetically
- [x] Your submission has a useful description
- [x] The description does not end with punctuation
- [x] Each table column should be padded with one space on either side
- [x] You have searched the repository for any relevant issues or pull requests
- [x] Any category you are creating has the minimum requirement of 3 items
- [x] All changes have been [squashed][squash-link] into a single commit

[squash-link]: <https://github.com/todotxt/todo.txt-android/wiki/Squash-All-Commits-Related-to-a-Single-Issue-into-a-Single-Commit>
