### PR TITLE
Adds RenderPDF.io

### DIFF
--- a/README.md
+++ b/README.md
@@ -393,6 +393,7 @@ For information on contributing to this project, please see the [contributing gu
 |                         [pdflayer](https://pdflayer.com)                          | HTML/URL to PDF                                                            | `apiKey` |  Yes  | Unknown |
 |                    [Pocket](https://getpocket.com/developer/)                     | Bookmarking service                                                        | `OAuth`  |  Yes  | Unknown |
 |                         [PrexView](https://prexview.com)                          | Data from XML or JSON to PDF, HTML or Image                                | `apiKey` |  Yes  | Unknown |
+|                       [RenderPDF.io](https://renderpdf.io/)                       | Fastest HTML to PDF, free 500 pdfs/month                                   | `apiKey` |  Yes  |   Yes   |
 |                         [Restpack](https://restpack.io/)                          | Provides screenshot, HTML to PDF and content extraction APIs               | `apiKey` |  Yes  | Unknown |
 |                     [Todoist](https://developer.todoist.com)                      | Todo Lists                                                                 | `OAuth`  |  Yes  | Unknown |
 |                      [Vector Express](http://vector.express)                      | Free vector file converting API                                            |    No    |  No   |   Yes   |


### PR DESCRIPTION
[RenderPDF.io](https://renderpdf.io) helps you to convert HTML to PDF super fast with easy integration.

Free user gets 500 PDFs/month + CDN-ready

- [x] Your submissions are formatted according to the guidelines in the [contributing guide](CONTRIBUTING.md)
- [x] Your additions are ordered alphabetically
- [x] Your submission has a useful description
- [x] The description does not end with punctuation
- [x] Each table column should be padded with one space on either side
- [x] You have searched the repository for any relevant issues or pull requests
- [x] Any category you are creating has the minimum requirement of 3 items
- [x] All changes have been [squashed][squash-link] into a single commit

[squash-link]: <https://github.com/todotxt/todo.txt-android/wiki/Squash-All-Commits-Related-to-a-Single-Issue-into-a-Single-Commit>
