### PR TITLE
Add PunkAPI

### DIFF
--- a/README.md
+++ b/README.md
@@ -468,6 +468,7 @@ For information on contributing to this project, please see the [contributing gu
 |                           [LCBO](https://lcboapi.com/)                           | Alcohol                                           | `apiKey` |  Yes  | Unknown |
 |                 [Open Brewery DB](https://www.openbrewerydb.org)                 | Breweries, Cideries and Craft Beer Bottle Shops   |    No    |  Yes  |   Yes   |
 |             [Open Food Facts](https://world.openfoodfacts.org/data)              | Food Products Database                            |    No    |  Yes  | Unknown |
+|                 [PunkAPI](https://github.com/alxiw/punkapi)                      | BrewDog's DIY Dog beer catalogue as an API        |    No    |  Yes  |   Yes   |
 |                 [Spoonacular](https://spoonacular.com/food-api)                  | Food and Recipes                                  | `apikey` |  Yes  | Unknown |
 |                [TacoFancy](https://github.com/evz/tacofancy-api)                 | Community-driven taco database                    |    No    |  No   | Unknown |
 | [The Report of the Week](https://github.com/andyklimczak/TheReportOfTheWeek-API) | Food & Drink Reviews                              |    No    |  Yes  | Unknown |


### PR DESCRIPTION
Add [PunkAPI](https://github.com/alxiw/punkapi) in Food & Drink section. This API provides a searchable catalog of BrewDog's DIY Dog beers recipes, allowing users to explore and filter various beer styles.

-   [x] My submission is formatted according to the guidelines in the [contributing guide](https://github.com/marcelscruz/public-apis/blob/main/CONTRIBUTING.md)
-   [x] My addition is ordered alphabetically
-   [x] My submission has a useful description
-   [x] The description does not have more than 100 characters
-   [x] The description does not end with punctuation
-   [x] Each table column is padded with one space on either side
-   [x] I have searched the repository for any relevant issues or pull requests
-   [x] Any category I am creating has the minimum requirement of 3 items
-   [x] All changes have been [squashed][squash-link] into a single commit

[squash-link]: <https://github.com/todotxt/todo.txt-android/wiki/Squash-All-Commits-Related-to-a-Single-Issue-into-a-Single-Commit>
