### PR TITLE
fix: add studio ghibli API

### DIFF
--- a/README.md
+++ b/README.md
@@ -98,6 +98,7 @@ For information on contributing to this project, please see the [contributing gu
 |          [What Anime](https://soruly.github.io/trace.moe-api/#/)          | Scan anime image to get specific detail           | `apiKey` |  Yes  | Unknown |
 |                [Mangadex](https://api.mangadex.org/docs/)                 | ad-free manga reader offering high-quality images |    No    |  Yes  | Unknown |
 |                    [Nekosia API](https://nekosia.cat)                     | Anime API with cute random images                 |    No    |  Yes  | Unknown |
+|                    [Studio Ghibli API](https://nekosia.cat)               | Resources from Studio Ghibli films                |    No    |  Yes  |   Yes   |
 
 **[⬆ Back to Index](#index)**
 

--- a/README.md
+++ b/README.md
@@ -98,7 +98,7 @@ For information on contributing to this project, please see the [contributing gu
 |          [What Anime](https://soruly.github.io/trace.moe-api/#/)          | Scan anime image to get specific detail           | `apiKey` |  Yes  | Unknown |
 |                [Mangadex](https://api.mangadex.org/docs/)                 | ad-free manga reader offering high-quality images |    No    |  Yes  | Unknown |
 |                    [Nekosia API](https://nekosia.cat)                     | Anime API with cute random images                 |    No    |  Yes  | Unknown |
-|                    [Studio Ghibli API](https://nekosia.cat)               | Resources from Studio Ghibli films                |    No    |  Yes  |   Yes   |
+|                    [Studio Ghibli API](https://ghibli.rest)               | Resources from Studio Ghibli films                |    No    |  Yes  |   Yes   |
 
 **[⬆ Back to Index](#index)**
 


### PR DESCRIPTION
Justs adds a new studio ghibli API to the list.

- [x] Your submissions are formatted according to the guidelines in the [contributing guide](CONTRIBUTING.md)
- [x] Your additions are ordered alphabetically
- [x] Your submission has a useful description
- [x] The description does not end with punctuation
- [x] Each table column should be padded with one space on either side
- [x] You have searched the repository for any relevant issues or pull requests
- [x] Any category you are creating has the minimum requirement of 3 items
- [x] All changes have been [squashed][squash-link] into a single commit

[squash-link]: <https://github.com/todotxt/todo.txt-android/wiki/Squash-All-Commits-Related-to-a-Single-Issue-into-a-Single-Commit>
