### PR TITLE
Add documentation-only contribution guidelines

### DIFF
--- a/.github/CONTRIBUTING.md
+++ b/.github/CONTRIBUTING.md
@@ -1,8 +1,8 @@
 # Contributing to public-api-lists
 
 > While the masses of pull requests and community involvement is appreciated, some pull requests have been specifically
-opened to market company APIs that offer paid solutions. This API list is not a marketing tool, but a tool to help the
-community build applications and use free, public APIs quickly and easily. Pull requests that are identified as marketing attempts will not be accepted.
+> opened to market company APIs that offer paid solutions. This API list is not a marketing tool, but a tool to help the
+> community build applications and use free, public APIs quickly and easily. Pull requests that are identified as marketing attempts will not be accepted.
 >
 > Thanks for understanding! :)
 
@@ -10,9 +10,9 @@ community build applications and use free, public APIs quickly and easily. Pull 
 
 Current API entry format:
 
-| API | Description | Auth | HTTPS | CORS |
-| --- | --- | --- | --- | --- |
-| API Title(Link to API webpage) | Description of API | Does this API require authentication? * | Does the API support HTTPS? | Does the API support [CORS](https://developer.mozilla.org/en-US/docs/Web/HTTP/CORS)? * |
+| API                            | Description        | Auth                                     | HTTPS                       | CORS                                                                                    |
+| ------------------------------ | ------------------ | ---------------------------------------- | --------------------------- | --------------------------------------------------------------------------------------- |
+| API Title(Link to API webpage) | Description of API | Does this API require authentication? \* | Does the API support HTTPS? | Does the API support [CORS](https://developer.mozilla.org/en-US/docs/Web/HTTP/CORS)? \* |
 
 Example entry:
 
@@ -22,20 +22,31 @@ Example entry:
 
 \* Currently, the only accepted inputs for the `Auth` field are as follows:
 
-* `OAuth` - _the API supports OAuth_
-* `apiKey` - _the API uses a private key string/token for authentication - try and use the correct parameter_
-* `X-Mashape-Key` - _the name of the header which may need to be sent_
-* `No` - _the API requires no authentication to run_
+- `OAuth` - _the API supports OAuth_
+- `apiKey` - _the API uses a private key string/token for authentication - try and use the correct parameter_
+- `X-Mashape-Key` - _the name of the header which may need to be sent_
+- `No` - _the API requires no authentication to run_
 
 \* Currently, the only accepted inputs for the `CORS` field are as follows:
 
-* `Yes` - _the API supports CORS_
-* `No` - _the API does not support CORS_
-* `Unknown` - _it is unknown if the API supports CORS_
+- `Yes` - _the API supports CORS_
+- `No` - _the API does not support CORS_
+- `Unknown` - _it is unknown if the API supports CORS_
 
 Please continue to follow the alphabetical ordering that is in place per section. Each table column should be padded with one space on either side.
 
 If an API seems to fall into multiple categories, please place the listing within the section most in line with the services offered through the API. For example, the Instagram API is listed under `Social` since it is mainly a social network, even though it could also apply to `Photography`.
+
+## Documentation Contributions
+
+You can also contribute by:
+
+- Fixing typos or grammar
+- Improving clarity of descriptions
+- Updating broken links
+- Improving formatting
+
+Documentation-only pull requests are welcome.
 
 ## Pull Request
 
@@ -45,14 +56,14 @@ Once you’ve submitted a pull request, the collaborators can review your propos
 
 ### Pull Request Pro Tips
 
-* [Fork][fork-link] the repository and [clone][clone-link] it locally.
-Connect your local repository to the original `upstream` repository by adding it as a [remote][remote-link].
-Pull in changes from `upstream` often so that you stay up to date and so when you submit your pull request,
-merge conflicts will be less likely. See more detailed instructions [here][syncing-link].
-* Create a [branch][branch-link] for your edits.
-* Contribute in the style of the project as outlined above. This makes it easier for the collaborators to merge
-and for others to understand and maintain in the future.
-* Please make sure you squash all commits together before opening a pull request. If your pull request requires changes upon review, please be sure to squash all additional commits as well. [This wiki page][squash-link] outlines the squash process.
+- [Fork][fork-link] the repository and [clone][clone-link] it locally.
+  Connect your local repository to the original `upstream` repository by adding it as a [remote][remote-link].
+  Pull in changes from `upstream` often so that you stay up to date and so when you submit your pull request,
+  merge conflicts will be less likely. See more detailed instructions [here][syncing-link].
+- Create a [branch][branch-link] for your edits.
+- Contribute in the style of the project as outlined above. This makes it easier for the collaborators to merge
+  and for others to understand and maintain in the future.
+- Please make sure you squash all commits together before opening a pull request. If your pull request requires changes upon review, please be sure to squash all additional commits as well. [This wiki page][squash-link] outlines the squash process.
 
 ### Open Pull Requests
 
@@ -64,14 +75,13 @@ During the discussion, you may be asked to make some changes to your pull reques
 
 If so, add more commits to your branch and push them – they will automatically go into the existing pull request!
 
-Thanks for being a part of this project, and we look forward to hearing from you soon! 
+Thanks for being a part of this project, and we look forward to hearing from you soon!
 
-[branch-link]: <http://guides.github.com/introduction/flow/>
-[clone-link]: <https://help.github.com/articles/cloning-a-repository/>
-[fork-link]: <http://guides.github.com/activities/forking/>
-[oauth-link]: <https://en.wikipedia.org/wiki/OAuth>
-[pr-link]: <https://help.github.com/articles/creating-a-pull-request/>
-[remote-link]: <https://help.github.com/articles/configuring-a-remote-for-a-fork/>
-[syncing-link]: <https://help.github.com/articles/syncing-a-fork>
-[squash-link]: <https://github.com/todotxt/todo.txt-android/wiki/Squash-All-Commits-Related-to-a-Single-Issue-into-a-Single-Commit>
-
+[branch-link]: http://guides.github.com/introduction/flow/
+[clone-link]: https://help.github.com/articles/cloning-a-repository/
+[fork-link]: http://guides.github.com/activities/forking/
+[oauth-link]: https://en.wikipedia.org/wiki/OAuth
+[pr-link]: https://help.github.com/articles/creating-a-pull-request/
+[remote-link]: https://help.github.com/articles/configuring-a-remote-for-a-fork/
+[syncing-link]: https://help.github.com/articles/syncing-a-fork
+[squash-link]: https://github.com/todotxt/todo.txt-android/wiki/Squash-All-Commits-Related-to-a-Single-Issue-into-a-Single-Commit


### PR DESCRIPTION
### What this PR does
- Adds a Documentation Contributions section to CONTRIBUTING.md

### Why this change is needed
- Helps beginners understand they can contribute through documentation improvements
- Encourages non-code contributions without changing any existing rules

This PR only improves documentation clarity and does not modify contribution policies.

