### PR TITLE
Add Stock Sentiment to Finance

### DIFF
--- a/README.md
+++ b/README.md
@@ -473,6 +473,7 @@ For information on contributing to this project, please see the [contributing gu
 |                    [Polygon.io](https://polygon.io/docs/)                | Real-time and historical stock market data, crypto and forex  | `apiKey` |  Yes  |   Yes   |
 |               [Razorpay IFSC](https://ifsc.razorpay.com/)                | Indian Financial Systems Code (Bank Branch Codes)             |    No    |  Yes  | Unknown |
 | [Indian Bank Data API](https://github.com/kaustubhk24/Indian-Banks-Data) | All Banks IFSC Code data,Search by IFSc or other details      |    No    |  Yes  | Unknown |
+|              [Stock Sentiment](https://api.adanos.org/docs)              | Reddit & X/Twitter sentiment analysis for stocks with buzz scores    | `apiKey` |  Yes  |   Yes   |
 |                 [Tradier](https://developer.tradier.com)                 | US equity/option market data (delayed, intraday, historical)  | `OAuth`  |  Yes  |   Yes   |
 |         [World Trading Data](https://www.worldtradingdata.com/)          | Market data provider                                          | `apiKey` |  Yes  | Unknown |
 |                 [YNAB](https://api.youneedabudget.com/)                  | Budgeting & Planning                                          | `OAuth`  |  Yes  |   Yes   |


### PR DESCRIPTION
Adding Stock Sentiment API to the Finance category.

**Stock Sentiment** provides Reddit & X/Twitter sentiment analysis for stocks with buzz scores.

## Checklist
- [x] Submission formatted according to guidelines
- [x] - [x] Addition ordered alphabetically (between Indian Bank Data API and Tradier)
- [x] - [x] Submission has a useful description
- [ ] - [x] Description does not end with punctuation
- [ ] - [x] Table columns padded with one space on either side
- [x] - [x] Searched the repository for relevant issues/PRs
- [ ] - [x] All changes in a single commit