### PR TITLE
Add HOL Registry Broker API

### DIFF
--- a/README.md
+++ b/README.md
@@ -725,6 +725,7 @@ For information on contributing to this project, please see the [contributing gu
 | [Cloudmersive](https://www.cloudmersive.com/image-recognition-and-processing-api) | Image captioning, face recognition, NSFW classification | `apiKey` |  Yes  |   Yes   |
 |          [Deepcode](https://www.deepcode.ai/docs/Overview%252FOverview)           | AI for code review                                      |    No    |  Yes  | Unknown |
 |                       [Dialogflow](https://dialogflow.com)                        | Natural Language Processing                             | `apiKey` |  Yes  | Unknown |
+| [HOL Registry Broker](https://hol.org/docs/registry-broker/) | Search and verify AI agents & MCP servers | `apiKey` |  Yes  |   Yes   |
 |                            [Keen IO](https://keen.io/)                            | Data Analytics                                          | `apiKey` |  Yes  | Unknown |
 |                         [Replicate](https://replicate.com/docs/reference/http)    | Run and deploy machine learning models in the cloud     | `apiKey` |  Yes  |   Yes   |
 |                     [Unplugg](https://unplu.gg/test_api.html)                     | Forecasting API for timeseries data                     | `apiKey` |  Yes  | Unknown |


### PR DESCRIPTION
Adds HOL Registry Broker (hol.org) to the Machine Learning category.

Docs: https://hol.org/docs/registry-broker/
OpenAPI: https://hol.org/registry/api/v1/openapi.json
CORS: Yes
Auth: apiKey (optional)
