### PR TITLE
Add LeadFinder API

### DIFF
--- a/README.md
+++ b/README.md
@@ -163,6 +163,7 @@ For information on contributing to this project, please see the [contributing gu
 |              [Freelancer](https://developers.freelancer.com)               | Hire freelancers to get work done                                         | `OAuth`  |  Yes  | Unknown |
 |             [Gmail](https://developers.google.com/gmail/api/)              | Flexible, RESTful access to the user's inbox                              | `OAuth`  |  Yes  | Unknown |
 |        [Google Analytics](https://developers.google.com/analytics/)        | Collect, configure and analyze your data to reach the right audience      | `OAuth`  |  Yes  | Unknown |
+| [LeadFinder](https://leadscraper-coral.vercel.app/api/v1/leads) | Free local business leads from Google Maps | No | Yes | Yes |
 |                       [LogoKit](https://logokit.com)                       | Logo API for brands, stocks, and cryptocurrencies                         | `apiKey` |  Yes  | Unknown |
 | [MailboxValidator](https://www.mailboxvalidator.com/api-single-validation) | Validate email address to improve deliverability                          | `apiKey` |  Yes  | Unknown |
 |                    [mailgun](https://www.mailgun.com/)                     | Email Service                                                             | `apiKey` |  Yes  | Unknown |


### PR DESCRIPTION
## Add LeadFinder API

Adding **LeadFinder** to the Business category.

**LeadFinder** is a free, no-auth REST API that returns local business leads from Google Maps. It provides business name, address, phone, website, rating, and reviews for any niche + city combination.

- **URL:** https://leadscraper-coral.vercel.app/api/v1/leads?niche=dentist&city=miami
- **Auth:** None required
- **HTTPS:** Yes
- **CORS:** Yes
- **Free tier:** 5 leads per request, no API key needed

Example: `GET /api/v1/leads?niche=restaurants&city=london`

Thank you for maintaining this awesome list!