### PR TITLE
Add Agent Hustle to Machine Learning section

### DIFF
--- a/README.md
+++ b/README.md
@@ -736,6 +736,7 @@ For information on contributing to this project, please see the [contributing gu
 |                                        API                                        | Description                                             |   Auth   | HTTPS |  CORS   |
 | :-------------------------------------------------------------------------------: | ------------------------------------------------------- | :------: | :---: | :-----: |
 | [Cloudmersive](https://www.cloudmersive.com/image-recognition-and-processing-api) | Image captioning, face recognition, NSFW classification | `apiKey` |  Yes  |   Yes   |
+| [Agent Hustle](https://agent.stakewatch.dev/api) | AI web services: scraping, research, screenshots, translation, summarization | `apiKey` | Yes | Yes |
 |          [Deepcode](https://www.deepcode.ai/docs/Overview%252FOverview)           | AI for code review                                      |    No    |  Yes  | Unknown |
 |                       [Dialogflow](https://dialogflow.com)                        | Natural Language Processing                             | `apiKey` |  Yes  | Unknown |
 | [HOL Registry Broker](https://hol.org/docs/registry-broker/) | Search and verify AI agents & MCP servers | `apiKey` |  Yes  |   Yes   |


### PR DESCRIPTION
**Agent Hustle** — AI-powered web services: scraping, deep research, screenshots, translation, summarization, data extraction, and code review.

- **URL:** https://agent.stakewatch.dev/api
- **Auth:** apiKey
- **HTTPS:** Yes
- **CORS:** Yes
- **Free tier:** Yes (free during beta)
- **Also on RapidAPI:** https://rapidapi.com/agenthustle/api/agent-hustle