### PR TITLE
Add Markbase - USPTO Trademark Search API

### DIFF
--- a/README.md
+++ b/README.md
@@ -168,6 +168,7 @@ For information on contributing to this project, please see the [contributing gu
 |                    [mailgun](https://www.mailgun.com/)                     | Email Service                                                             | `apiKey` |  Yes  | Unknown |
 |                    [Mailjet](https://www.mailjet.com/)                     | Email Service                                                             | `apiKey` |  Yes  | Unknown |
 |                   [markerapi](http://www.markerapi.com/)                   | Trademark Search                                                          |    No    |  No   | Unknown |
+|                     [Markbase](https://markbase.co)                        | Search 14M+ USPTO trademarks with fuzzy search and autocomplete           |    No    |  Yes  |   Yes   |
 |                  [Trello](https://developers.trello.com/)                  | Boards, lists and cards to help you organize and prioritize your projects | `OAuth`  |  Yes  | Unknown |
 |                  [Tomba Email finder](https://tomba.io/)                   | Email Finder for B2B sales and email marketing                            | `apiKey` |  Yes  |   Yes   |
 |                    [Clientsbee](https://clientsbee.com)                    | Free leads for bussiness and technographics data                          | `apikey` |  Yes  |   No    |


### PR DESCRIPTION
## Add Markbase API

**API:** [Markbase](https://markbase.co)  
**Category:** Business  
**Auth:** No  
**HTTPS:** Yes  
**CORS:** Yes  

### Description
Free REST API for searching, filtering, and retrieving data from 14M+ U.S. trademarks in the USPTO registry. Fuzzy search, autocomplete, faceted results, daily syncs.

- Docs: https://api.markbase.co/docs
- OpenAPI: https://api.markbase.co/openapi.json