### PR TITLE
Add Arch Tools — 61 AI tools API with x402 USDC payments

### DIFF
--- a/README.md
+++ b/README.md
@@ -740,6 +740,7 @@ For information on contributing to this project, please see the [contributing gu
 | :-------------------------------------------------------------------------------: | ------------------------------------------------------- | :------: | :---: | :-----: |
 | [Cloudmersive](https://www.cloudmersive.com/image-recognition-and-processing-api) | Image captioning, face recognition, NSFW classification | `apiKey` |  Yes  |   Yes   |
 | [Agent Hustle](https://agent.stakewatch.dev/api) | AI web services: scraping, research, screenshots, translation, summarization | `apiKey` | Yes | Yes |
+| [Arch Tools](https://archtools.dev) | 61 AI tools: generation, scraping, crypto, sentiment, OCR, TTS. x402 USDC payments + API keys | `apiKey` |  Yes  |   Yes   |
 |          [Deepcode](https://www.deepcode.ai/docs/Overview%252FOverview)           | AI for code review                                      |    No    |  Yes  | Unknown |
 |                       [Dialogflow](https://dialogflow.com)                        | Natural Language Processing                             | `apiKey` |  Yes  | Unknown |
 | [HOL Registry Broker](https://hol.org/docs/registry-broker/) | Search and verify AI agents & MCP servers | `apiKey` |  Yes  |   Yes   |


### PR DESCRIPTION
Adds [Arch Tools](https://archtools.dev) to the Machine Learning section.

**61 production AI tools** including text generation, web scraping, crypto data, sentiment analysis, OCR, text-to-speech, and more.

- **Auth**: API key (free tier: 250 credits/month) or x402 USDC payments (no key needed)
- **HTTPS**: Yes
- **CORS**: Yes
- **Docs**: https://archtools.dev/docs
- **OpenAPI**: https://archtools.dev/openapi.json
- **MCP Server**: https://arch-tools-mcp.onrender.com/mcp