### PR TITLE
Add StackData SaaS Pricing API

### DIFF
--- a/README.md
+++ b/README.md
@@ -168,6 +168,7 @@ For information on contributing to this project, please see the [contributing gu
 |                    [mailgun](https://www.mailgun.com/)                     | Email Service                                                             | `apiKey` |  Yes  | Unknown |
 |                    [Mailjet](https://www.mailjet.com/)                     | Email Service                                                             | `apiKey` |  Yes  | Unknown |
 |                   [markerapi](http://www.markerapi.com/)                   | Trademark Search                                                          |    No    |  No   | Unknown |
+|              [StackData SaaS Pricing](https://greg-rg-git.github.io/stackdata-store/api/)               | Verified pricing data for 797 SaaS tools across 13 categories            |    No    |  Yes  |   Yes   |
 |                  [Trello](https://developers.trello.com/)                  | Boards, lists and cards to help you organize and prioritize your projects | `OAuth`  |  Yes  | Unknown |
 |                  [Tomba Email finder](https://tomba.io/)                   | Email Finder for B2B sales and email marketing                            | `apiKey` |  Yes  |   Yes   |
 |                    [Clientsbee](https://clientsbee.com)                    | Free leads for bussiness and technographics data                          | `apikey` |  Yes  |   No    |


### PR DESCRIPTION
## About the API

**Name:** StackData SaaS Pricing
**URL:** https://greg-rg-git.github.io/stackdata-store/api/
**Category:** Business
**Auth:** No
**HTTPS:** Yes
**CORS:** Yes

## What it does

Free JSON API providing verified pricing data for 797 SaaS tools across 13 categories. Useful for developers building pricing comparison tools, benchmarking dashboards, or analytics products.

## Checklist

- [x] Entry placed alphabetically in the Business section (after markerapi, before Trello)
- [x] Description is under 100 characters (63 chars)
- [x] API has full free access (no auth required)
- [x] HTTPS supported
- [x] CORS supported