### PR TITLE
Add IteraTools to Machine Learning section

### DIFF
--- a/README.md
+++ b/README.md
@@ -752,6 +752,7 @@ For information on contributing to this project, please see the [contributing gu
 |          [Deepcode](https://www.deepcode.ai/docs/Overview%252FOverview)           | AI for code review                                      |    No    |  Yes  | Unknown |
 |                       [Dialogflow](https://dialogflow.com)                        | Natural Language Processing                             | `apiKey` |  Yes  | Unknown |
 | [HOL Registry Broker](https://hol.org/docs/registry-broker/) | Search and verify AI agents & MCP servers | `apiKey` |  Yes  |   Yes   |
+| [IteraTools](https://api.iteratools.com) | 36+ pay-per-use tools for AI agents: image gen, TTS, scraping, OCR, WhatsApp, sentiment, summarize and more. MCP-compatible. x402 payments. | `apiKey` |  Yes  |   Yes   |
 |                            [Keen IO](https://keen.io/)                            | Data Analytics                                          | `apiKey` |  Yes  | Unknown |
 |                         [Replicate](https://replicate.com/docs/reference/http)    | Run and deploy machine learning models in the cloud     | `apiKey` |  Yes  |   Yes   |
 |                     [Unplugg](https://unplu.gg/test_api.html)                     | Forecasting API for timeseries data                     | `apiKey` |  Yes  | Unknown |


### PR DESCRIPTION
## Description

Add [IteraTools](https://api.iteratools.com) to the **Machine Learning** section.

## New API Entry

| API | Description | Auth | HTTPS | CORS |
|-----|-------------|------|-------|------|
| [IteraTools](https://api.iteratools.com) | 36+ pay-per-use tools for AI agents: image gen, TTS, scraping, OCR, WhatsApp, sentiment, summarize and more. MCP-compatible. x402 payments. | `apiKey` | Yes | Yes |

## Links
- **API Base URL:** https://api.iteratools.com
- **Docs:** https://iteratools.com/docs
- **Health/tools list:** https://api.iteratools.com/health

## Category Justification
IteraTools is a multi-tool API specifically designed for AI agents, with tools spanning image generation, OCR, text-to-speech, web scraping, sentiment analysis, summarization, and more — making it a natural fit for the Machine Learning section.

## Checklist
- [x] API is publicly available
- [x] HTTPS supported
- [x] CORS supported
- [x] Authentication required (apiKey)
- [x] Entry is alphabetically placed (between HOL Registry Broker and Keen IO)
