### PR TITLE
Add ArcNautical Vessel Check API

### DIFF
--- a/README.md
+++ b/README.md
@@ -1086,6 +1086,7 @@ For information on contributing to this project, please see the [contributing gu
 **[⬆ Back to Index](#index)**
 
 ### Transportation
+| [ArcNautical Vessel Check](https://github.com/SaltyTaro/vessel-check-api) | Vessel sanctions screening, ownership transparency, and vetting grade for any IMO number | No | Yes | Yes |
 
 |                                                                API                                                                 | Description                                                                                      |   Auth   | HTTPS |  CORS   |
 | :--------------------------------------------------------------------------------------------------------------------------------: | ------------------------------------------------------------------------------------------------ | :------: | :---: | :-----: |


### PR DESCRIPTION
## API Details

- **Name:** ArcNautical Vessel Check
- **URL:** https://arcnautical.com/api/v1/vessels/{imo}/check
- **Auth:** None required
- **HTTPS:** Yes
- **CORS:** Yes
- **Category:** Transportation

## Description

Free API for instant vessel sanctions screening (OFAC, EU, UN), ownership transparency scoring, and vetting intelligence. Returns a traffic-light sanctions status (GREEN/AMBER/RED), ownership opacity score, and vetting grade (A-E) for any 7-digit IMO number.

No API key required. No signup. Rate limited to 100 requests/hour.

## Example

```bash
curl https://arcnautical.com/api/v1/vessels/9034690/check
```

```json
{
  "imo": "9034690",
  "sanctions": { "status": "RED", "detail": "1 match found" },
  "ownership": { "opacity": "MEDIUM", "score": 60 },
  "vetting": { "grade": "B", "score": 36 }
}
```

Documentation: https://github.com/SaltyTaro/vessel-check-api