### PR TITLE
Add LinkShrink API to URL Shorteners category

### DIFF
--- a/README.md
+++ b/README.md
@@ -1150,6 +1150,7 @@ For information on contributing to this project, please see the [contributing gu
 | :---------------------------------------------------: | ---------------------------------------------- | :------: | :---: | :-----: |
 |    [Bitly](http://dev.bitly.com/get_started.html)     | URL shortener and link management              | `OAuth`  |  Yes  | Unknown |
 |         [CleanURI](https://cleanuri.com/docs)         | URL shortener service                          |    No    |  Yes  |   Yes   |
+|      [LinkShrink](https://linkshrink.dev)       | Free privacy-first URL shortener API           |    No    |  Yes  |   No    |
 | [Rebrandly](https://developers.rebrandly.com/v1/docs) | Custom URL shortener for sharing branded links | `apiKey` |  Yes  | Unknown |
 |            [Spoo.me](https://spoo.me/docs)            | URL Shortener with advanced analytics          |    No    |  Yes  |   Yes   |
 |              [T.LY](https://t.ly/docs/)               | URL Shortener With Short Links                 | `apiKey` |  Yes  | Unknown |


### PR DESCRIPTION
## Summary

- Adds [LinkShrink](https://linkshrink.dev) to the **URL Shorteners** category
- LinkShrink is a free privacy-first URL shortener API (HTTPS, no auth, no CORS)
- Entry placed in alphabetical order within the URL Shorteners section