### PR TITLE
Add VOLO API

### DIFF
--- a/README.md
+++ b/README.md
@@ -1040,6 +1040,7 @@
 |                              [Transport for The Netherlands](http://www.ns.nl/reisinformatie/ns-api)                               | NS, only trains                                                                                  | `apiKey` |  No   | Unknown |
 |                        [Transport for United States](http://www.nextbus.com/xmlFeedDocs/NextBusXMLFeed.pdf)                        | NextBus API                                                                                      |    No    |  No   | Unknown |
 |                                    [Transport for Washington, US](https://developer.wmata.com/)                                    | Washington Metro transport API                                                                   | `OAuth`  |  Yes  | Unknown |
+|                                          [VOLO](https://www.flyvolo.ai/for-agents)                                                 | Private aviation charter search, quotes, fleet, and empty legs                                   | `apiKey` |  Yes  |   Yes   |
 
 **[⬆ Back to Index](#index)**
 


### PR DESCRIPTION
## Add VOLO API

**Category:** Transportation

| API | Description | Auth | HTTPS | CORS |
|:---:|:---|:---:|:---:|:---:|
| [VOLO](https://www.flyvolo.ai/for-agents) | Private aviation charter search, quotes, fleet, and empty legs | `apiKey` | Yes | Yes |

**Link to API documentation:** https://www.flyvolo.ai/for-agents

VOLO is an AI-powered private aviation platform with a REST API (OpenAPI 3.1), MCP server, and CLI. Free tier includes fleet browsing (200+ aircraft), route search (226 routes), airport lookup (7,900+ airports), empty leg inventory, and charter quote requests.