### PR TITLE
Add LinkShrink and FreeKit free APIs

### DIFF
--- a/README.md
+++ b/README.md
@@ -175,6 +175,7 @@
 |     [AnonFiles](https://anonfiles.com/docs/api)      | File Sharing and Storage |    No    |  Yes  | Unknown |
 |          [Box](https://developer.box.com/)           | File Sharing and Storage | `OAuth`  |  Yes  | Unknown |
 |    [Dropbox](https://www.dropbox.com/developers)     | File Sharing and Storage | `OAuth`  |  Yes  | Unknown |
+| [FreeKit](https://freekit.dev) | Free instant HTML hosting and static page publishing API | No |  Yes  |   Yes   |
 | [Google Drive](https://developers.google.com/drive/) | File Sharing and Storage | `OAuth`  |  Yes  | Unknown |
 |        [Mega.nz](https://mega.io/developers)         | File Sharing And Storage |    No    |  Yes  | Unknown |
 |        [OneDrive](https://dev.onedrive.com/)         | File Sharing and Storage | `OAuth`  |  Yes  | Unknown |
@@ -1048,6 +1049,7 @@
 |                          API                          | Description                                    |   Auth   | HTTPS |  CORS   |
 | :---------------------------------------------------: | ---------------------------------------------- | :------: | :---: | :-----: |
 |    [Bitly](http://dev.bitly.com/get_started.html)     | URL shortener and link management              | `OAuth`  |  Yes  | Unknown |
+| [LinkShrink](https://linkshrink.dev) | Privacy-first URL shortener with no tracking or API keys | No |  Yes  |   Yes   |
 | [Rebrandly](https://developers.rebrandly.com/v1/docs) | Custom URL shortener for sharing branded links | `apiKey` |  Yes  | Unknown |
 |              [T.LY](https://t.ly/docs/)               | URL Shortener With Short Links                 | `apiKey` |  Yes  | Unknown |
 |           [urlfy](https://urlfy.org/api-doc)          | A simple and fast URL shortening service       | No |  Yes  |   Yes   |


### PR DESCRIPTION
## Added APIs

### LinkShrink (URL Shorteners)
- **URL:** https://linkshrink.dev
- **Description:** Privacy-first URL shortener with no tracking or API keys
- **Auth:** No
- **HTTPS:** Yes
- **CORS:** Yes

### FreeKit (Cloud Storage & File Sharing)
- **URL:** https://freekit.dev
- **Description:** Free instant HTML hosting and static page publishing API
- **Auth:** No
- **HTTPS:** Yes
- **CORS:** Yes

Both APIs are completely free, require no authentication, and are part of the [SoftVoyagers](https://github.com/softvoyagers) open ecosystem.