### PR TITLE
Add SharpAPI API

### DIFF
--- a/README.md
+++ b/README.md
@@ -941,6 +941,7 @@
 |           [JCDecaux Bike](https://developer.jcdecaux.com/)            | JCDecaux's self-service bicycles                                                            |    `apiKey`     |  Yes  | Unknown |
 | [NBA Stats](https://any-api.com/nba_com/nba_com/docs/API_Description) | Current and historical NBA Statistics                                                       |       No        |  Yes  | Unknown |
 |       [NHL Records and Stats](https://gitlab.com/dword4/nhlapi)       | NHL historical data and statistics                                                          |       No        |  Yes  | Unknown |
+|               [SharpAPI](https://docs.sharpapi.io)                | Real-time sports betting odds from 20+ sportsbooks with +EV detection                      |    `apiKey`     |  Yes  |   Yes   |
 |                [Strava](https://strava.github.io/api/)                | Connect with athletes, activities and more                                                  |     `OAuth`     |  Yes  | Unknown |
 |          [TheSportsDB](https://www.thesportsdb.com/api.php)           | Crowd-Sourced Sports Data and Artwork                                                       |    `apiKey`     |  Yes  |   Yes   |
 |                [Wger](https://wger.de/en/software/api)                | Workout manager data as exercises, muscles or equipment                                     |    `apiKey`     |  Yes  | Unknown |


### PR DESCRIPTION
## Add SharpAPI API

**Category:** Sports & Fitness

SharpAPI is a real-time sports betting odds API that aggregates odds from 20+ US sportsbooks into a single normalized schema with built-in +EV detection, arbitrage alerts, and SSE streaming.

- **Free tier:** 12 req/min (17,280/day), no credit card required
- **Auth:** API key (`X-API-Key` header)
- **HTTPS:** Yes
- **CORS:** Yes
- **Docs:** https://docs.sharpapi.io