### PR TITLE
Add ZipCheckup water quality API

### DIFF
--- a/README.md
+++ b/README.md
@@ -416,6 +416,7 @@
 |                      [PVWatts](https://developer.nrel.gov/docs/solar/pvwatts/v6/)                      | Energy production photovoltaic (PV) energy systems                                | `apiKey` |  Yes  | Unknown |
 | [UK Carbon Intensity](https://carbon-intensity.github.io/api-definitions/#carbon-intensity-api-v1-0-0) | The Official Carbon Intensity API for Great Britain developed by National Grid    |    No    |  Yes  | Unknown |
 |                         [WeatherStack](https://weatherstack.com/documentation)                         | Humidity & Air & Pressure API                                                     | `apiKey` |  Yes  | Unknown |
+|                     [ZipCheckup](https://api.zipcheckup.com/v1)                                        | U.S. drinking water quality data by ZIP code from EPA and 20+ federal sources     |    No    |  Yes  |   Yes   |
 
 **[⬆ Back to Index](#index)**
 


### PR DESCRIPTION
Adds [ZipCheckup](https://api.zipcheckup.com/v1) to the **Environment** section.

Free, public REST API providing U.S. drinking water quality data by ZIP code. Coverage: 41,344 ZIP codes across all 50 states + DC. Data sourced from EPA SDWIS and 20+ other federal agencies.

- **Auth:** No
- **HTTPS:** Yes
- **CORS:** Yes
- **License:** CC BY 4.0
- **GitHub:** https://github.com/artakulov/us-water-quality-data