### PR TITLE
Add SEC Insider Trading API to Finance

### DIFF
--- a/README.md
+++ b/README.md
@@ -447,6 +447,7 @@
 |                       [Plaid](https://plaid.com/)                        | Connect with users’ bank accounts and access transaction data | `apiKey` |  Yes  | Unknown |
 |                    [Polygon.io](https://polygon.io/docs/)                | Real-time and historical stock market data, crypto and forex  | `apiKey` |  Yes  |   Yes   |
 |               [Razorpay IFSC](https://ifsc.razorpay.com/)                | Indian Financial Systems Code (Bank Branch Codes)             |    No    |  Yes  | Unknown |
+| [SEC Insider Trading](https://rapidapi.com/lulzasaur/api/sec-insider-trades) | Real-time SEC Form 4 insider trading data for any public company | `apiKey` | Yes | Unknown |
 |              [Stock Sentiment](https://api.adanos.org/docs)              | Reddit & X/Twitter sentiment analysis for stocks with buzz scores    | `apiKey` |  Yes  |   Yes   |
 |                 [Tradier](https://developer.tradier.com)                 | US equity/option market data (delayed, intraday, historical)  | `OAuth`  |  Yes  |   Yes   |
 |                 [ValueRay](https://www.valueray.com/api)                 | Quantitative and sentiment data for stocks and ETFs           |    No     | Yes  |   Yes   |


### PR DESCRIPTION
Adds the SEC Insider Trading API which provides real-time SEC Form 4 insider trading data. Track stock purchases, sales, and option exercises by corporate insiders. Free tier available (200 requests/month).