### PR TITLE
Add Coinnect to Currency Exchange

### DIFF
--- a/README.md
+++ b/README.md
@@ -235,6 +235,7 @@
 |                                                     API                                                      | Description                                                        |   Auth   | HTTPS |  CORS   |
 | :----------------------------------------------------------------------------------------------------------: | ------------------------------------------------------------------ | :------: | :---: | :-----: |
 |                        [1Forge](https://1forge.com/forex-data-api/api-documentation)                         | Forex currency market data                                         | `apiKey` |  Yes  | Unknown |
+|                              [Coinnect](https://coinnect.bot/docs)                                           | Open money transfer routing across fiat, crypto and P2P networks   | `apiKey` |  Yes  |   Yes   |
 |                                [CurrencyFreaks](https://currencyfreaks.com/)                                 | Currency conversion with latest & historical forex exchange rates  | `apiKey` |  Yes  | Unknown |
 |                           [Currencylayer](https://currencylayer.com/documentation)                           | Exchange rates and currency conversion                             | `apiKey` |  Yes  | Unknown |
 | [Czech National Bank](https://www.cnb.cz/cs/financni_trhy/devizovy_trh/kurzy_devizoveho_trhu/denni_kurz.xml) | A collection of exchange rates                                     |    No    |  Yes  | Unknown |


### PR DESCRIPTION
## Add Coinnect to Currency Exchange

[Coinnect](https://coinnect.bot/docs) is an open money transfer routing API that finds the cheapest path across fiat, crypto, and P2P networks. Uses Dijkstra's algorithm over 29K+ live edges from 80+ adapters.

- **Auth**: apiKey
- **HTTPS**: Yes
- **CORS**: Yes