### PR TITLE
Add launch.pics to Photography section

### DIFF
--- a/README.md
+++ b/README.md
@@ -831,6 +831,7 @@
 |      [Giphy](https://developers.giphy.com/docs/)      | Get all your gifs                                          | `apiKey` |  Yes  | Unknown |
 |          [Gyazo](https://gyazo.com/api/docs)          | Upload images                                              | `apiKey` |  Yes  | Unknown |
 |          [Imgur](https://apidocs.imgur.com/)          | Images                                                     | `OAuth`  |  Yes  | Unknown |
+|      [launch.pics](https://launch.pics)       | AI-powered image processing API with 39 endpoints and workflow builder | `apiKey` |  Yes  |   Yes   |
 |        [Lorem Picsum](https://picsum.photos/)         | Images from Unsplash                                       |    No    |  Yes  | Unknown |
 |          [ObjectCut](https://objectcut.com/)          | Image Background removal                                   | `apiKey` |  Yes  |   Yes   |
 |         [Pexels](https://www.pexels.com/api/)         | Free Stock Photos and Videos                               | `apiKey` |  Yes  |   Yes   |


### PR DESCRIPTION
## Addition

Adds [launch.pics](https://launch.pics) to the **Photography** section.

**launch.pics** is a free AI-powered image processing API with 39 REST endpoints for image manipulation (resize, crop, filter, watermark, text overlay, effects) and a natural language visual workflow builder.

- **URL**: https://launch.pics
- **API Docs**: https://launch.pics/api/
- **Auth**: apiKey (for some features)
- **HTTPS**: Yes
- **CORS**: Yes
- **GitHub**: https://github.com/keptlive/launch.pics