### PR TITLE
Add Congressional Stock Brain to Finance section

### DIFF
--- a/README.md
+++ b/README.md
@@ -442,6 +442,7 @@
 |                 [IEX](https://iextrading.com/developer/)                 | Realtime stock data                                           | `apiKey` |  Yes  |   Yes   |
 |                 [IG](https://labs.ig.com/gettingstarted)                 | Spreadbetting and CFD Market Data                             | `apiKey` |  Yes  | Unknown |
 | [Indian Bank Data API](https://github.com/kaustubhk24/Indian-Banks-Data) | All Banks IFSC Code data,Search by IFSc or other details      |    No    |  Yes  | Unknown |
+| [Congressional Stock Brain](https://congressionalstockbrain.com) | AI-powered tool scoring U.S. STOCK Act lawmaker trade disclosures for retail investors | No | Yes | Yes |
 |        [KeepRule](https://github.com/henu-wang/keeprule-api)             | Investment principles and quotes from Buffett, Munger & more  |    No    |  Yes  |   Yes   |
 |                 [Mboum API](https://docs.mboum.com)                 | Real-time Stock market and Options Data                             | `apiKey` |  Yes  | Unknown |
 |                       [Plaid](https://plaid.com/)                        | Connect with users’ bank accounts and access transaction data | `apiKey` |  Yes  | Unknown |


### PR DESCRIPTION
## Type of Change
- [x] Adding a new API entry
## Description
Adding **Congressional Stock Brain** to the Finance category.

**Congressional Stock Brain** (https://congressionalstockbrain.com) is a free AI-powered tool that aggregates and scores all U.S. STOCK Act disclosures — the mandatory public financial trade filings from U.S. lawmakers — making them accessible and actionable for retail investors.

## Verification
- [x] The API URL is active and accessible: https://congressionalstockbrain.com
- [ ] - [x] No Auth required for basic access (free tier)
- [ ] - [x] HTTPS: Yes
- [ ] - [x] CORS: Yes
- [ ] - [x] No duplicate exists in the Finance section
- [ ] - [x] Entry follows the existing table format
- [ ] - [x] Alphabetically placed (after "Indian Bank Data API", before "KeepRule")