### PR TITLE
Add PaperClean

### DIFF
--- a/README.md
+++ b/README.md
@@ -384,6 +384,7 @@
 |     [CustomJS](https://www.customjs.space/integration/pdf-api/html-to-pdf)        | HTML to PDF or PDF to PNG/Text & merging/extraction APIs       | `apiKey` |  Yes  | Unknown |
 |                       [DynamicDocs](https://advicement.io)                        | Generate dynamic PDFs with JSON to PDF API based on LaTeX      | `apiKey` |  Yes  | Unknown |
 |                          [File.io](https://www.file.io)                           | File Sharing                                                   |    No    |  Yes  | Unknown |
+|              [PaperClean](https://paperclean.ip1.cc/api/docs)                     | Clean document photos for printing, remove shadows, fix lighting | `apiKey` |  Yes  |   Yes   |
 |                        [PDFBolt](https://pdfbolt.com/docs)                        | HTML to PDF conversion with templates and AI generation        | `apiKey` |  Yes  |   Yes   |
 |                      [pdfEndpoint](https://pdfendpoint.com)                       | HTML or URL to PDF                                             | `apiKey` |  Yes  |   No    |
 |                         [pdflayer](https://pdflayer.com)                          | HTML/URL to PDF                                                | `apiKey` |  Yes  | Unknown |


### PR DESCRIPTION
## Add PaperClean to Documents & Productivity

**API:** [PaperClean](https://paperclean.ip1.cc/api/docs)

**Description:** Clean document photos for printing, remove shadows, fix lighting

**Auth:** apiKey (X-API-Key header)
**HTTPS:** Yes
**CORS:** Yes

PaperClean transforms photos of documents into clean, print-ready versions with a free tier (50 images/month, no credit card required).

- [API docs](https://paperclean.ip1.cc/api/docs)
- [OpenAPI spec](https://paperclean.ip1.cc/api/openapi.json)
- [Free API key](https://paperclean.ip1.cc/developers)