### PR TITLE
Add TCGApi to Games & Comics

### DIFF
--- a/README.md
+++ b/README.md
@@ -535,6 +535,7 @@
 |                   [Scryfall](https://scryfall.com/docs/api)                   | Magic: The Gathering database                                                                                |       No        |  Yes  |   Yes   |
 |        [Steam](https://developer.valvesoftware.com/wiki/Steam_Web_API)        | Steam Client Interaction                                                                                     |     `OAuth`     |  Yes  | Unknown |
 |                    [SuperHeroes](https://superheroapi.com)                    | All SuperHeroes and Villains data from all universes under a single API                                      |    `apiKey`     |  Yes  | Unknown |
+| [TCGApi](https://tcgapi.dev/introduction/) | Trading card game prices and historical data across 89+ games | `apiKey` | Yes | No |
 |                       [TCGdex](https://www.tcgdex.dev/)                       | A Multilanguage Pokémon TCG Database with Cards Pictures and most of the informations contained on the cards |       No        |  Yes  |   Yes   |
 |        [TheGamestracker](https://thegamestracker.com/server-info-api)         | Game servers informations in JSON format                                                                     |    `apiKey`     |  Yes  |   Yes   |
 |         [Traveller Map](https://travellermap.com/doc/api)                     | [Traveller TTRPG](https://www.mongoosepublishing.com/collections/traveller-rpgs) map world, sub sector and sector information in json, PDF and other formats|       No        |  Yes  |   No    |


### PR DESCRIPTION
Adds TCGApi to the Games & Comics section.

TCGApi provides trading card game pricing data sourced from TCGPlayer for 89+ games (Pokemon, Magic: The Gathering, Yu-Gi-Oh!, Lorcana, One Piece, Flesh and Blood, and many others). Free tier of 100 requests/day, real-time and historical pricing, set/card metadata, OpenAPI 3.1 spec.

- Free tier: yes (100 req/day, no card required)
- Auth: API key via `X-API-Key` header
- HTTPS: yes
- CORS: no (origin restricted to tcgapi.dev)
- Documentation: https://tcgapi.dev/introduction/

Inserted alphabetically between SuperHeroes and TCGdex. Verified locally with `python3 .github/scripts/sort_entries.py` — Games & Comics section reports no ordering issues.