### PR TITLE
Add Deckaura Horoscope API

### DIFF
--- a/README.md
+++ b/README.md
@@ -806,6 +806,7 @@
 | :-------------------------------------------------------------: | ---------------------------------------------------------------------- | :------: | :---: | :-----: |
 |            [Advice Slip](http://api.adviceslip.com/)            | Generate random advice slips                                           |    No    |  Yes  | Unknown |
 |          [chucknorris.io](https://api.chucknorris.io)           | JSON API for hand curated Chuck Norris jokes                           |    No    |  Yes  | Unknown |
+|     [Deckaura Horoscope](https://horoscope.deckaura.com)       | Daily horoscope readings for all 12 zodiac signs (overview, love, career, lucky number) updated daily at 00:00 UTC |    No    |  Yes  |   Yes   |
 |              [Echoes](https://echoes.soferity.com)              | Quotes From Around The World                                           |    No    |  Yes  |   Yes   |
 |               [FavQs.com](https://favqs.com/api)                | FavQs allows you to collect, discover and share your favorite quotes   | `apiKey` |  Yes  | Unknown |
 |           [Forismatic](http://forismatic.com/en/api/)           | Inspirational Quotes                                                   |    No    |  No   | Unknown |


### PR DESCRIPTION
Adding Deckaura Horoscope to the Personality category.

- **Endpoint:** https://horoscope.deckaura.com/api/daily/{sign}
- **Example:** https://horoscope.deckaura.com/api/daily/aries
- **Auth:** None
- **HTTPS:** Yes
- **CORS:** Yes
- **Cost:** Free

Returns daily horoscope JSON for all 12 zodiac signs with overview, love, career, and lucky number fields. Updated daily via Cloudflare Cron Triggers. No API key required.

Entry inserted alphabetically between chucknorris.io and Echoes.