### PR TITLE
Add Xquik to Social section

### DIFF
--- a/README.md
+++ b/README.md
@@ -925,6 +925,7 @@
 |            [Twitter](https://developer.twitter.com/en/docs)            | Read and write Twitter data                                                                       | `OAuth`  |  Yes  |   No    |
 |                  [TwitterApi](http://twitterapi.io/)                   | Mass Twitter data read API                                                                        | `apiKey` |  Yes  |   No    |
 |                     [vk](https://vk.com/dev/sites)                     | Read and write vk data                                                                            | `OAuth`  |  Yes  | Unknown |
+|                    [Xquik](https://docs.xquik.com)                     | All-in-one X automation API for tweets, giveaways, monitoring & analytics                         | `apiKey` |  Yes  | Unknown |
 
 **[⬆ Back to Index](#index)**
 


### PR DESCRIPTION
## Type of Change

- [x] Adding a new API entry

## API Details

**API Name:** Xquik  
**Category/Section:** Social  
**Auth:** apiKey  
**HTTPS:** Yes  
**CORS:** Unknown  

## Description

Xquik is a public REST API with 40+ endpoints for X (Twitter) automation - tweet lookup, user profiles, followers, timelines, giveaway draws, real-time monitoring with webhooks, and AI-powered composition.

- **Docs**: https://docs.xquik.com
- **OpenAPI spec**: https://xquik.com/openapi.json
- **Free tier**: Pay-per-use endpoints available without a subscription
