### PR TITLE
Add Statistics of the World API

### DIFF
--- a/README.md
+++ b/README.md
@@ -452,6 +452,7 @@
 |       [PredScope](https://predscope.com/api/markets.json)        | Free prediction market odds and analytics data from Polymarket |    No    |  Yes  |   Yes   |
 |               [Razorpay IFSC](https://ifsc.razorpay.com/)                | Indian Financial Systems Code (Bank Branch Codes)             |    No    |  Yes  | Unknown |
 |              [Stock Sentiment](https://api.adanos.org/docs)              | Reddit & X/Twitter sentiment analysis for stocks with buzz scores    | `apiKey` |  Yes  |   Yes   |
+| [Statistics of the World](https://statisticsoftheworld.com/api-docs) | GDP, population, inflation & 440+ indicators for 218 countries |    No    |  Yes  |   Yes   |
 |                 [Tradier](https://developer.tradier.com)                 | US equity/option market data (delayed, intraday, historical)  | `OAuth`  |  Yes  |   Yes   |
 |                 [ValueRay](https://www.valueray.com/api)                 | Quantitative and sentiment data for stocks and ETFs           |    No     | Yes  |   Yes   |
 |         [World Trading Data](https://www.worldtradingdata.com/)          | Market data provider                                          | `apiKey` |  Yes  | Unknown |


### PR DESCRIPTION
## Description

Adding [Statistics of the World](https://statisticsoftheworld.com/api-docs) to the Finance section.

**API Details:**
- **Description**: GDP, population, inflation & 440+ indicators for 218 countries
- **Auth**: No (100 requests/day without authentication, free API key for higher limits)
- **HTTPS**: Yes
- **CORS**: Yes
- **Data sources**: IMF World Economic Outlook, World Bank WDI, WHO, FRED, United Nations

The API returns JSON and covers macroeconomic, demographic, health, education, and environmental indicators.