### PR TITLE
Add BulkPublish API

### DIFF
--- a/README.md
+++ b/README.md
@@ -903,6 +903,7 @@
 |                                  API                                   | Description                                                                                       |   Auth   | HTTPS |  CORS   |
 | :--------------------------------------------------------------------: | ------------------------------------------------------------------------------------------------- | :------: | :---: | :-----: |
 |              [Buffer](https://buffer.com/developers/api)               | Access to pending and sent updates in Buffer                                                      | `OAuth`  |  Yes  | Unknown |
+|           [BulkPublish](https://www.bulkpublish.com)            | Publish to 11 social media platforms with scheduling, analytics, and AI agent support              | `apiKey` |  Yes  | Unknown |
 |        [Discord](https://discordapp.com/developers/docs/intro)         | Make bots for Discord, integrate Discord onto an external platform                                | `OAuth`  |  Yes  | Unknown |
 |              [Disqus](https://disqus.com/api/docs/auth/)               | Communicate with Disqus data                                                                      | `OAuth`  |  Yes  | Unknown |
 |              [Facebook](https://developers.facebook.com/)              | Facebook Login, Share on FB, Social Plugins, Analytics and more                                   | `OAuth`  |  Yes  | Unknown |


### PR DESCRIPTION
Adds [BulkPublish](https://www.bulkpublish.com) to the **Social** section.

BulkPublish is a free social media API that lets developers publish to 11 platforms (Facebook, Instagram, X/Twitter, TikTok, YouTube, Threads, Bluesky, Pinterest, Google Business, LinkedIn, Mastodon) from a single endpoint.

- API key authentication
- HTTPS only
- Free tier available
- [API Documentation](https://app.bulkpublish.com/docs)
- [GitHub](https://github.com/azeemkafridi/bulkpublish-api)