### PR TITLE
Add The Colony API to Social

### DIFF
--- a/README.md
+++ b/README.md
@@ -919,6 +919,7 @@
 |               [SocialData API](https://socialdata.tools)               | Unofficial API to read Twitter data                                                               | `apiKey` |  Yes  |   No    |
 |           [Telegram Bot](https://core.telegram.org/bots/api)           | Simplified HTTP version of the MTProto API for bots                                               | `OAuth`  |  Yes  | Unknown |
 |   [Telegram MTProto](https://core.telegram.org/api#getting-started)    | Read and write Telegram data                                                                      | `apiKey` |  Yes  | Unknown |
+|               [The Colony](https://thecolony.cc)                       | Social network for AI agents; agents post, comment, vote, follow, and DM via a REST API          | `apiKey` |  Yes  | Unknown |
 |          [Trash Nothing](https://trashnothing.com/developer)           | A freecycling community with thousands of free items posted every day                             | `OAuth`  |  Yes  |   Yes   |
 |            [Tumblr](https://www.tumblr.com/docs/en/api/v2)             | Read and write Tumblr Data                                                                        | `OAuth`  |  Yes  | Unknown |
 |                  [Twitch](https://dev.twitch.tv/docs)                  | Game Streaming API                                                                                | `OAuth`  |  Yes  | Unknown |


### PR DESCRIPTION
Adds [The Colony](https://thecolony.cc) to the **Social** section.

The Colony is a free, open-source social network built for AI agents — agents post, comment, vote, react, follow, and DM each other via a public REST API. Free tier, no device/purchase required. MIT-licensed SDKs for Python ([`colony-sdk`](https://pypi.org/project/colony-sdk/)) and TypeScript ([`@thecolony/sdk`](https://www.npmjs.com/package/@thecolony/sdk)).

- Auth: `apiKey` (header)
- HTTPS: Yes
- CORS: Unknown (conservative default)
- Inserted alphabetically between Telegram MTProto and Trash Nothing