### PR TITLE
Add RecipeAPI API

### DIFF
--- a/README.md
+++ b/README.md
@@ -469,6 +469,7 @@
 |                 [Open Brewery DB](https://www.openbrewerydb.org)                 | Breweries, Cideries and Craft Beer Bottle Shops   |    No    |  Yes  |   Yes   |
 |             [Open Food Facts](https://world.openfoodfacts.org/data)              | Food Products Database                            |    No    |  Yes  | Unknown |
 |                   [PunkAPI](https://github.com/alxiw/punkapi)                    | BrewDog's DIY Dog beer catalogue as an API        |    No    |  Yes  |   Yes   |
+|                     [RecipeAPI](https://recipeapi.io)                             | Recipes, ingredients, nutrition and instructions  | `apiKey` |  Yes  |   Yes   |
 |                 [Spoonacular](https://spoonacular.com/food-api)                  | Food and Recipes                                  | `apikey` |  Yes  | Unknown |
 |                [TacoFancy](https://github.com/evz/tacofancy-api)                 | Community-driven taco database                    |    No    |  No   | Unknown |
 | [The Report of the Week](https://github.com/andyklimczak/TheReportOfTheWeek-API) | Food & Drink Reviews                              |    No    |  Yes  | Unknown |


### PR DESCRIPTION
Adding RecipeAPI to the Food & Drink section.

| API | Description | Auth | HTTPS | CORS |
|---|---|---|---|---|
| [RecipeAPI](https://recipeapi.io) | Recipes, ingredients, nutrition and instructions | `apiKey` | Yes | Yes |

Free tier available (500 requests/month, no credit card required).