### PR TITLE
Add Japan Neighborhoods API

### DIFF
--- a/README.md
+++ b/README.md
@@ -633,6 +633,7 @@
 |                     [FEC](https://api.open.fec.gov/developers/)                     | Information on campaign donations in federal elections                                    | `apiKey` |  Yes  | Unknown |
 | [Federal Register](https://www.federalregister.gov/reader-aids/developer-resources) | The Daily Journal of the United States Government                                         |    No    |  Yes  | Unknown |
 |         [Food Standards Agency](http://ratings.food.gov.uk/open-data/en-GB)         | UK food hygiene rating data API                                                           |    No    |  No   | Unknown |
+| [Japan Neighborhoods](https://japanneighborhoods.com/developers) | Tokyo neighborhood crime statistics, safety scores, and station data (5,078 areas, 2018-2024) |    No    |  Yes  |   Yes   |
 |               [Open Government, Australia](https://www.data.gov.au/)                | Australian Government Open Data                                                           |    No    |  Yes  | Unknown |
 |                  [Open Government, Belgium](https://data.gov.be/)                   | Belgium Government Open Data                                                              |    No    |  Yes  | Unknown |
 |                 [Open Government, Canada](http://open.canada.ca/en)                 | Canadian Government Open Data                                                             |    No    |  No   | Unknown |


### PR DESCRIPTION
Adds **Japan Neighborhoods API** to the Government section.

Free REST API for Tokyo neighborhood crime data:
- 5,078 neighborhoods, 7 years (2018-2024)
- No auth, HTTPS, CORS enabled
- Sourced from Tokyo Metropolitan Police open data
- Docs: https://japanneighborhoods.com/developers