### PR TITLE
Add FXMacroData API to Finance and Currency Exchange sections

### DIFF
--- a/README.md
+++ b/README.md
@@ -244,7 +244,7 @@
 |                              [Exchangeratesapi.io](https://exchangeratesapi.io)                              | Exchange rates with currency conversion                            | `apiKey` |  Yes  |   Yes   |
 |                                         [Fixer.io](http://fixer.io)                                          | Exchange rates and currency conversion                             | `apiKey` |  Yes  | Unknown |
 |                               [Frankfurter](https://www.frankfurter.app/docs)                                | Exchange rates, currency conversion and time series                |    No    |  Yes  |   Yes   |
-|                              [FXMacroData](https://fxmacrodata.com/api-docs)                                 | Real-time forex macroeconomic data from central bank announcements | `apiKey` |  Yes  |   Yes   |
+|                                   [FXMacroData](https://fxmacrodata.com)                                    | Real-time forex macroeconomic data from central bank announcements | `apiKey` |  Yes  |   Yes   |
 |                                    [FxRatesAPI](https://fxratesapi.com/)                                     | Real-time exchange rates, historical rates and currency conversion | `apiKey` |  Yes  |   No    |
 |                                       [ratesapi](https://ratesapi.io)                                        | Free exchange rates and historical rates                           |    No    |  Yes  | Unknown |
 
@@ -443,7 +443,6 @@
 |           [CommodityPriceAPI](https://commoditypriceapi.com/)            | Real-time & historical commodity prices (metals, energy, etc) | `apiKey` |  Yes  | Unknown |
 |             [Earnings Feed](https://earningsfeed.com/api)                | Real-time SEC filings, insider trades, and institutional holdings | `apiKey` |  Yes  |   No    |
 |               [Financial Data](https://financialdata.net/)               | Stock Market and Financial Data                               | `apiKey` |  Yes  | Unknown |
-|               [FXMacroData](https://fxmacrodata.com/api-docs)                | Real-time forex macroeconomic data from central bank announcements | `apiKey` |  Yes  |   Yes   |
 |                 [IEX](https://iextrading.com/developer/)                 | Realtime stock data                                           | `apiKey` |  Yes  |   Yes   |
 |                 [IG](https://labs.ig.com/gettingstarted)                 | Spreadbetting and CFD Market Data                             | `apiKey` |  Yes  | Unknown |
 | [Indian Bank Data API](https://github.com/kaustubhk24/Indian-Banks-Data) | All Banks IFSC Code data,Search by IFSc or other details      |    No    |  Yes  | Unknown |

--- a/README.md
+++ b/README.md
@@ -244,6 +244,7 @@
 |                              [Exchangeratesapi.io](https://exchangeratesapi.io)                              | Exchange rates with currency conversion                            | `apiKey` |  Yes  |   Yes   |
 |                                         [Fixer.io](http://fixer.io)                                          | Exchange rates and currency conversion                             | `apiKey` |  Yes  | Unknown |
 |                               [Frankfurter](https://www.frankfurter.app/docs)                                | Exchange rates, currency conversion and time series                |    No    |  Yes  |   Yes   |
+|                              [FXMacroData](https://fxmacrodata.com/api-docs)                                 | Real-time forex macroeconomic data from central bank announcements | `apiKey` |  Yes  |   Yes   |
 |                                    [FxRatesAPI](https://fxratesapi.com/)                                     | Real-time exchange rates, historical rates and currency conversion | `apiKey` |  Yes  |   No    |
 |                                       [ratesapi](https://ratesapi.io)                                        | Free exchange rates and historical rates                           |    No    |  Yes  | Unknown |
 
@@ -442,6 +443,7 @@
 |           [CommodityPriceAPI](https://commoditypriceapi.com/)            | Real-time & historical commodity prices (metals, energy, etc) | `apiKey` |  Yes  | Unknown |
 |             [Earnings Feed](https://earningsfeed.com/api)                | Real-time SEC filings, insider trades, and institutional holdings | `apiKey` |  Yes  |   No    |
 |               [Financial Data](https://financialdata.net/)               | Stock Market and Financial Data                               | `apiKey` |  Yes  | Unknown |
+|               [FXMacroData](https://fxmacrodata.com/api-docs)                | Real-time forex macroeconomic data from central bank announcements | `apiKey` |  Yes  |   Yes   |
 |                 [IEX](https://iextrading.com/developer/)                 | Realtime stock data                                           | `apiKey` |  Yes  |   Yes   |
 |                 [IG](https://labs.ig.com/gettingstarted)                 | Spreadbetting and CFD Market Data                             | `apiKey` |  Yes  | Unknown |
 | [Indian Bank Data API](https://github.com/kaustubhk24/Indian-Banks-Data) | All Banks IFSC Code data,Search by IFSc or other details      |    No    |  Yes  | Unknown |


### PR DESCRIPTION
## What does this PR do?

Adds [FXMacroData](https://fxmacrodata.com/api-docs) to the **Finance** and **Currency Exchange** sections.

## API Details

- **URL**: https://fxmacrodata.com/api-docs
- **Auth**: API key (query parameter)
- **HTTPS**: Yes
- **CORS**: Yes

FXMacroData provides real-time forex macroeconomic data sourced directly from central bank announcements, covering 18 currencies. Available as a REST API with OpenAPI spec and also as an MCP server.

- [PyPI package](https://pypi.org/project/fxmacrodata/)
- [GitHub](https://github.com/fxmacrodata/fxmacrodata)
- [OpenAPI spec](https://fxmacrodata.com/api/openapi.json)