### PR TITLE
Add Agentic Engineering Jobs API to Jobs

### DIFF
--- a/README.md
+++ b/README.md
@@ -671,6 +671,7 @@
 |                                           API                                            | Description                                                                     |   Auth   | HTTPS |  CORS   |
 | :--------------------------------------------------------------------------------------: | ------------------------------------------------------------------------------- | :------: | :---: | :-----: |
 |                     [Adzuna](https://developer.adzuna.com/overview)                      | Job board aggregator                                                            | `apiKey` |  Yes  | Unknown |
+| [Agentic Engineering Jobs](https://agentic-engineering-jobs.com/api-reference)           | Job board for engineers building agentic systems (LangChain, LlamaIndex, CrewAI)|    No    |  Yes  | No      |
 |                   [Careerjet](https://www.careerjet.com/partners/api/)                   | Job search engine                                                               | `apiKey` |  No   | Unknown |
 |                     [DevITjobs](https://devitjobs.us/api/jobsLight)                      | Jobs for software developers                                                    |    No    |  Yes  | Unknown |
 |                      [Himalayas](https://himalayas.app/api)                         | Remote job board and search engine                                              |    No    |  Yes  |   Yes   |

--- a/README.md
+++ b/README.md
@@ -671,7 +671,7 @@
 |                                           API                                            | Description                                                                     |   Auth   | HTTPS |  CORS   |
 | :--------------------------------------------------------------------------------------: | ------------------------------------------------------------------------------- | :------: | :---: | :-----: |
 |                     [Adzuna](https://developer.adzuna.com/overview)                      | Job board aggregator                                                            | `apiKey` |  Yes  | Unknown |
-| [Agentic Engineering Jobs](https://agentic-engineering-jobs.com/api-reference)           | Job board for engineers building agentic systems (LangChain, LlamaIndex, CrewAI)|    No    |  Yes  | No      |
+| [Agentic Engineering Jobs](https://agentic-engineering-jobs.com/api-reference)           | Job board for engineers building agentic systems (LangChain, LlamaIndex, CrewAI)|    No    |  Yes  |   Yes   |
 |                   [Careerjet](https://www.careerjet.com/partners/api/)                   | Job search engine                                                               | `apiKey` |  No   | Unknown |
 |                     [DevITjobs](https://devitjobs.us/api/jobsLight)                      | Jobs for software developers                                                    |    No    |  Yes  | Unknown |
 |                      [Himalayas](https://himalayas.app/api)                         | Remote job board and search engine                                              |    No    |  Yes  |   Yes   |


### PR DESCRIPTION
Adding a free public API for the Jobs section.

- Free, no auth for read endpoints
- HTTPS, OpenAPI 3.0 spec at `/api/v1/openapi.json`
- Niche: agentic AI engineering jobs (LangChain, LlamaIndex, CrewAI, etc.)
- Docs: https://agentic-engineering-jobs.com/api-reference

Placed alphabetically between Adzuna and Careerjet.