### PR TITLE
Add Random Profiles to Test Data

### DIFF
--- a/README.md
+++ b/README.md
@@ -967,6 +967,7 @@
 |                [Micro-Jaymock](https://micro-jaymock.now.sh/)                 | Tiny API mocking microservice for generating fake JSON data |    No    |  Yes  |   No    |
 |                         [Mockae](https://mockae.com/)                         | Fake REST API powered by Lua                                |    No    |  Yes  |   Yes   |
 |            [Mockerito](https://mockerito.com/?ref=public-api-lists)           | Free mock REST APIs across different business domains       |    No    |  Yes  |   Yes   |
+|             [Random Profiles](https://random-profiles.com)                    | Fake user profiles and companies with 100+ fields each      | `apiKey` |  Yes  |   Yes   |
 |                [Randommer](https://randommer.io/randommer-api)                | Random data generator                                       | `apiKey` |  Yes  |   Yes   |
 |                      [RandomUser](https://randomuser.me)                      | Generates random user data                                  |    No    |  Yes  | Unknown |
 |                       [RoboHash](https://robohash.org/)                       | Generate random robot/alien avatars                         |    No    |  Yes  | Unknown |


### PR DESCRIPTION
## Type of Change

- [x] Adding a new API entry

## Checklist

- [x] Entry format: `| [Name](URL) | Description | Auth | HTTPS | CORS |`
- [x] Auth value is `apiKey`
- [x] HTTPS value is `Yes`
- [x] CORS value is `Yes`
- [x] Description does not end with punctuation
- [x] Entry is placed in alphabetical order within Test Data
- [x] Columns padded with one space on either side
- [x] No existing entries removed
- [x] Searched for duplicates (no existing Random Profiles entry)
- [x] API link working and returns documentation: https://random-profiles.com
- [x] Single commit

## API Details

**API Name:** Random Profiles
**Category/Section:** Test Data
**URL:** https://random-profiles.com
**Docs:** https://random-profiles.com/openapi.json

Generates fake user profiles and companies for tests, seed data, and demo scenarios. 1,000 pre-seeded profiles with 100+ fields each (name, email, phone, address, job, financials, social, education, vehicle, relationships…), 1,000 AI-generated company logos, and a cross-resource graph linking profiles to companies as employees and colleagues. Free tier: 100 profiles + 500 images + 100 companies per day.