### PR TITLE
Add Crime Brasil API (Government)

### DIFF
--- a/README.md
+++ b/README.md
@@ -626,6 +626,7 @@
 |                            [Code.gov](https://code.gov)                             | The primary platform for Open Source and code sharing for the U.S. Federal Government     | `apiKey` |  Yes  | Unknown |
 |                  [Colorado Data Engine](http://codataengine.org/)                   | Formatted and geolocated Colorado public data                                             |    No    |  Yes  | Unknown |
 |           [Colorado Information Marketplace](https://data.colorado.gov/)            | Colorado State Government Open Data                                                       |    No    |  Yes  | Unknown |
+|                   [Crime Brasil](https://crimebrasil.com.br/imprensa)               | Brazilian public-safety data — 3M geocoded crime incidents, PRF highway accidents, DATASUS violence (CC BY 4.0) |    No    |  Yes  | Unknown |
 |                          [Data.gov](https://api.data.gov/)                          | US Government Data                                                                        | `apiKey` |  Yes  | Unknown |
 |       [Deutscher Bundestag DIP](https://dip.bundestag.de/über-dip/hilfe/api)        | Access to German Bundestag DIP entities (e.g. activities, persons, printed material)      | `apiKey` |  Yes  | Unknown |
 |      [District of Columbia Open Data](http://opendata.dc.gov/pages/using-apis)      | Contains D.C. government public datasets, including crime, GIS, financial data, and so on |    No    |  Yes  | Unknown |

--- a/README.md
+++ b/README.md
@@ -626,7 +626,7 @@
 |                            [Code.gov](https://code.gov)                             | The primary platform for Open Source and code sharing for the U.S. Federal Government     | `apiKey` |  Yes  | Unknown |
 |                  [Colorado Data Engine](http://codataengine.org/)                   | Formatted and geolocated Colorado public data                                             |    No    |  Yes  | Unknown |
 |           [Colorado Information Marketplace](https://data.colorado.gov/)            | Colorado State Government Open Data                                                       |    No    |  Yes  | Unknown |
-|                   [Crime Brasil](https://crimebrasil.com.br/imprensa)               | Brazilian public-safety data — 3M geocoded crime incidents, PRF highway accidents, DATASUS violence (CC BY 4.0) |    No    |  Yes  | Unknown |
+|                       [Crime Brasil](https://crimebrasil.com.br)                    | Brazilian public-safety data — 3M geocoded crime incidents, PRF highway accidents, DATASUS violence (CC BY 4.0) |    No    |  Yes  | Unknown |
 |                          [Data.gov](https://api.data.gov/)                          | US Government Data                                                                        | `apiKey` |  Yes  | Unknown |
 |       [Deutscher Bundestag DIP](https://dip.bundestag.de/über-dip/hilfe/api)        | Access to German Bundestag DIP entities (e.g. activities, persons, printed material)      | `apiKey` |  Yes  | Unknown |
 |      [District of Columbia Open Data](http://opendata.dc.gov/pages/using-apis)      | Contains D.C. government public datasets, including crime, GIS, financial data, and so on |    No    |  Yes  | Unknown |


### PR DESCRIPTION
Adds Crime Brasil to the Government section.

**API:** https://crimebrasil.com.br/imprensa
**Scope:** Brazilian public-safety data — 3 million geocoded crime incidents (Rio Grande do Sul, neighborhood-level), municipality-level aggregates for Minas Gerais and Rio de Janeiro, national PRF DATATRAN highway-accident records, DATASUS SINAN interpersonal-violence records (all 26 states + DF).
**License:** CC BY 4.0
**Auth:** None
**HTTPS:** Yes
**CORS:** Yes

Inserted alphabetically between 'Colorado Information Marketplace' and 'Data.gov'.

DOI-backed dataset mirrors for citation:
- Zenodo: 10.5281/zenodo.19711971
- Figshare: 10.6084/m9.figshare.32086188
- Harvard Dataverse: doi:10.7910/DVN/5TZFSX
- Kaggle: valdovaldo/minas-gerais-violent-crime-2019-2026

🤖 Generated with [Claude Code](https://claude.com/claude-code)