### PR TITLE
Add PermisAPI to Government category

### DIFF
--- a/README.md
+++ b/README.md
@@ -644,6 +644,7 @@
 |                   [Open Government, Romania](http://data.gov.ro/)                   | Romania Government Open Data                                                              |    No    |  No   | Unknown |
 |                   [Open Government, Taiwan](https://data.gov.tw/)                   | Taiwan Government Open Data                                                               |    No    |  Yes  | Unknown |
 |                    [Open Government, USA](https://www.data.gov/)                    | United States Government Open Data                                                        |    No    |  Yes  | Unknown |
+|                      [PermisAPI](https://permisapi.fr)                               | 311k French building permits (Sitadel) with geocoding, webhooks, Python SDK               | `apiKey` |  Yes  |   Yes   |
 |                      [PolitiData](https://politidata.ca)                            | Canadian political financing, lobbying registrations and communications                    | `apiKey` |  Yes  | Unknown |
 |                     [ProcureData](https://procuredata.ca)                           | Canadian federal procurement contracts, tenders and awards                                 | `apiKey` |  Yes  | Unknown |
 |             [Represent by Open North](https://represent.opennorth.ca/)              | Find Canadian Government Representatives                                                  |    No    |  Yes  | Unknown |


### PR DESCRIPTION
Adds PermisAPI — a REST API exposing 311,000+ French building permits (Sitadel dataset) to the Government category.

## Details

- **Name**: PermisAPI
- **URL**: https://permisapi.fr
- **Category**: Government
- **Description**: 311k French building permits (Sitadel) with geocoding, webhooks, Python SDK
- **Auth**: `apiKey` (X-API-Key header)
- **HTTPS**: Yes
- **CORS**: Yes (verified: preflight OPTIONS returns access-control-allow-origin/methods/headers)

## Free tier

- 500 requests/month, no credit card required
- Paid tiers: 49€ to 1,999€+ / month

## Context

French building permits are published monthly by the Ministère de la Transition écologique (SDES) under the Etalab open license 2.0. PermisAPI transforms the raw CSV into a REST API with:

- 97.2% geocoding coverage (via the French Base Adresse Nationale)
- 11 query filters (department, municipality, type, dates, area, SIREN, etc.)
- Geospatial search (PostGIS radius queries)
- HMAC-SHA256 signed webhooks for real-time alerts
- Official Python SDK on PyPI: `pip install permisapi-client`

## Placement

Inserted alphabetically between "Open Government, USA" and "PolitiData" in the Government category.