### PR TITLE
Add Urantia Papers API to Books

### DIFF
--- a/README.md
+++ b/README.md
@@ -123,6 +123,7 @@
 |          [Open Library](https://openlibrary.org/developers/api)           | Books, book covers and related data                                                      |   No    |  Yes  | Unknown |
 | [Penguin Publishing](http://www.penguinrandomhouse.biz/webservices/rest/) | Books, book covers and related data                                                      |   No    |  Yes  | Unknown |
 |            [Rig Veda](https://aninditabasu.github.io/indica/)             | Gods and poets, their categories, and the verse meters, with the mandal and sukta number |   No    |  Yes  | Unknown |
+|         [Urantia Papers](https://urantia.dev)         | Full-text and semantic search across the Urantia Papers, with audio narration, entities and translations |   No    |  Yes  |   Yes   |
 
 **[⬆ Back to Index](#index)**
 


### PR DESCRIPTION
adds the Urantia Papers API to the Books section. it's a free, no-auth, https + cors public API for full-text and semantic search across the Urantia Papers, with audio narration, entities, and translations.

- docs: https://urantia.dev
- openapi spec: https://api.urantia.dev/openapi.json
- license: MIT (code) / CC0 (content)

added alphabetically between Thirukkural and Vedic Society. description is 99 chars.
