### PR TITLE
Add x402 Data API - HTTP 402 micro-payment developer data APIs

### DIFF
--- a/README.md
+++ b/README.md
@@ -228,6 +228,7 @@
 |                  [NiceHash](https://docs.nicehash.com/)                  | Largest Crypto Mining Marketplace                                                                                                  | `apiKey` |  Yes  | Unknown |
 |              [Poloniex](https://api-docs.poloniex.com/spot)              | US based digital asset exchange                                                                                                    | `apiKey` |  Yes  | Unknown |
 |       [WorldCoinIndex](https://www.worldcoinindex.com/apiservice)        | Cryptocurrencies Prices                                                                                                            | `apiKey` |  Yes  | Unknown |
+|                   [x402 Data API](https://goto-spring-php-instructor.trycloudflare.com)                   | Developer data APIs with x402 HTTP 402 payment protocol - pay per request using USDC on Base chain                                | `apiKey` |  Yes  | Unknown |
 
 **[⬆ Back to Index](#index)**
 


### PR DESCRIPTION
## x402 Data API

Developer data APIs with x402 HTTP 402 payment protocol - pay per request using USDC on Base chain.

### Features
- GitHub Trending repositories ($0.01 USDC/request)
- NPM package statistics ($0.005 USDC/request)
- HackerNews top stories ($0.005 USDC/request)
- Crypto price lookup ($0.003 USDC/request)

### How it works
Uses x402 protocol (HTTP 402 Payment Required) for micro-payments on Base chain.

### Endpoints
- `GET /api/github/trending` - GitHub trending repos
- `GET /api/npm/stats/:package` - NPM package stats  
- `GET /api/hackernews/top` - HN top stories
- `GET /api/crypto/price/:symbol` - Crypto prices

Added to Cryptocurrency section.