### PR TITLE
Add DiscGolf API

### DIFF
--- a/README.md
+++ b/README.md
@@ -936,6 +936,7 @@
 |        [Cartola FC](https://github.com/wgenial/cartrolandofc)         | The Cartola FC API serves to check the partial points of your team                          |       No        |  Yes  | Unknown |
 |                [City Bikes](http://api.citybik.es/v2/)                | City Bikes around the world                                                                 |       No        |  No   | Unknown |
 |                 [CricData](https://cricketdata.org/)                  | Ultimate Cricket data API - Score, Scorecard, Players data, Fantasy API                     |    `apiKey`     |  Yes  | Unknown |
+|                [DiscGolf](https://discgolfapi.com/docs/)              | Structured disc golf course data                                                            |       No        |  Yes  |   Yes   |
 |                      [F1 API](https://f1api.dev)                      | Free F1 data in real time with his own NPM package                                          |       No        |  Yes  | Unknown |
 |        [F1 Data API](https://github.com/Jacobbrewer1/f1-data)         | Formula 1 data API that delivers data from the F1 Archive dating back to 1950               |       No        |  Yes  |   No    |
 |                   [Fitbit](https://dev.fitbit.com/)                   | Fitbit Information                                                                          |     `OAuth`     |  Yes  | Unknown |


### PR DESCRIPTION
Adds DiscGolf, a free read-only API for structured disc golf course data.

Documentation:
https://discgolfapi.com/docs/

OpenAPI:
https://discgolfapi.com/openapi.json

The API currently focuses on course, country, region and recent update data.