### PR TITLE
Add NotaSalud API

### DIFF
--- a/README.md
+++ b/README.md
@@ -660,6 +660,7 @@
 |           [Healthcare.gov](https://www.healthcare.gov/developers/)            | Educational content about the US Health Insurance Marketplace                                |    No    |  Yes  | Unknown |
 | [ICD-10 Codes](https://clinicaltables.nlm.nih.gov/apidoc/icd10cm/v3/doc.html) | List of all healthcare diagnosis codes                                                       |    No    |  Yes  | Unknown |
 |                [Lexigram](https://docs.lexigram.io/v1/welcome)                | NLP that extracts mentions of clinical concepts from text, gives access to clinical ontology | `apiKey` |  Yes  | Unknown |
+| [NotaSalud](https://notasalud.com/api-cie-10) | Spanish CIE-10 code search API | No | Yes | No |
 |          [NPPES](https://npiregistry.cms.hhs.gov/registry/help-api)           | National Plan & Provider Enumeration System, info on healthcare providers registered in US   |    No    |  Yes  | Unknown |
 |               [Nutritionix](https://developer.nutritionix.com/)               | Worlds largest verified nutrition database                                                   | `apiKey` |  Yes  | Unknown |
 |                        [openFDA](https://open.fda.gov)                        | Public FDA data about drugs, devices and foods                                               |    No    |  Yes  | Unknown |


### PR DESCRIPTION
## Type of Change

- [x] Adding a new API entry
- [ ] Fixing a broken link
- [ ] Updating an existing entry
- [ ] Documentation / formatting fix
- [ ] Other (please describe):

## Checklist

- [x] Entry format: `| [Name](URL) | Description | Auth | HTTPS | CORS |`
- [x] Auth value is one of: `No`, `apiKey`, `OAuth`, `X-Mashape-Key`
- [x] HTTPS value is `Yes` or `No`
- [x] CORS value is `Yes`, `No`, or `Unknown`
- [x] Description does **not** end with punctuation
- [x] Entry is placed in **alphabetical order** within the correct section
- [x] Each table column is padded with one space on either side
- [x] I have **not removed** any existing entries
- [x] I have searched the list for duplicates (same API name or URL)
- [x] The API link is working and returns JSON
- [x] All changes have been squashed into a single commit

## API Details

**API Name:** NotaSalud
**Category/Section:** Health
**Why this API is useful:** It provides a free Spanish CIE-10 code search endpoint and reference pages for developers building healthcare, education, or internal lookup tools.

Verified endpoint example: https://notasalud.com/buscar/cie-10?q=diabetes&limit=3. Access-Control-Allow-Origin was not observed, so CORS is listed as No.
