### PR TITLE
Add TaxID to Data Validation

### DIFF
--- a/README.md
+++ b/README.md
@@ -262,6 +262,7 @@
 |                   [PurgoMalum](http://www.purgomalum.com)                   | Content validator against profanity & obscenity                       |    No    |  No   | Unknown |
 |       [Trestle](https://trestleiq.com/phone-validation-api/)                | Validates the phone number and provides phone metadata                | `apiKey` |  Yes  |   Yes   |
 | [US Autocomplete](https://smartystreets.com/docs/cloud/us-autocomplete-api) | Enter address data quickly with real-time address suggestions         | `apiKey` |  Yes  |   Yes   |
+| [TaxID](https://www.taxid.dev/docs) | EU VAT number validation with company name and address lookup across 27 member states | `apiKey` | Yes | Unknown |
 |    [US Extract](https://smartystreets.com/products/apis/us-extract-api)     | Extract postal addresses from any text including emails               | `apiKey` |  Yes  |   Yes   |
 |   [US Street Address](https://smartystreets.com/docs/cloud/us-street-api)   | Validate and append data for any US postal address                    | `apiKey` |  Yes  |   Yes   |
 |                      [vatlayer](https://vatlayer.com)                       | VAT number validation                                                 |    No    |  Yes  | Unknown |


### PR DESCRIPTION
Adding TaxID to the Data Validation category.

TaxID is a REST API for validating EU VAT numbers against the EU Commission's VIES system. It returns the company name and address from each national tax authority for all 27 EU member states. Free tier available with 100 validations/month, no credit card required.

- Documentation: https://www.taxid.dev/docs
- Auth: API key
- HTTPS: Yes
- Free tier: 100 validations/month

Formatting checks:
- Ordered alphabetically within the Data Validation section
- Columns padded with a space on either side
- Description kept short and factual
- Single commit