### PR TITLE
Add Sharpe API to Cryptocurrency

### DIFF
--- a/README.md
+++ b/README.md
@@ -227,6 +227,7 @@
 |             [Nexchange](https://nexchange2.docs.apiary.io/)              | Automated cryptocurrency exchange service                                                                                          |    No    |  No   |   Yes   |
 |                  [NiceHash](https://docs.nicehash.com/)                  | Largest Crypto Mining Marketplace                                                                                                  | `apiKey` |  Yes  | Unknown |
 |              [Poloniex](https://api-docs.poloniex.com/spot)              | US based digital asset exchange                                                                                                    | `apiKey` |  Yes  | Unknown |
+|               [Sharpe](https://www.sharpe.ai/docs/free-api)              | Crypto derivatives, funding, arbitrage, narratives, listings, and news data                                                        |    No    |  Yes  | Unknown |
 |       [WorldCoinIndex](https://www.worldcoinindex.com/apiservice)        | Cryptocurrencies Prices                                                                                                            | `apiKey` |  Yes  | Unknown |
 
 **[⬆ Back to Index](#index)**


### PR DESCRIPTION
## Type of Change

- [x] Adding a new API entry

## API Details

API Name: Sharpe
Category/Section: Cryptocurrency
Why this API is useful: Sharpe adds crypto market-data endpoints for derivatives positioning, funding rates, arbitrage, narrative rotation, exchange listings, and news. It fits the Cryptocurrency section alongside exchange and market-data APIs such as Coinpaprika, DexPaprika, and Poloniex.

Notes:
- Entry is append-only and uses the 5-column table format.
- The description has no ending punctuation, per CONTRIBUTING.md.
- Public endpoints are available without a required API key.

Disclosure: self-submission from the Sharpe team.