### PR TITLE
Add PsyQuiz API to Personality section

### DIFF
--- a/README.md
+++ b/README.md
@@ -816,6 +816,7 @@
 |            [Meme](https://github.com/D3vd/Meme_Api)             | JSON API for a random meme scraped from reddit                         |    No    |  Yes  | Unknown |
 |        [NaMoMemes](https://github.com/theIYD/NaMoMemes)         | Memes on Narendra Modi                                                 |    No    |  Yes  | Unknown |
 | [Programming Quotes](https://programming-quotesapi.vercel.app/) | An api which generates quotes from programmers                         |    No    |  Yes  |   Yes   |
+|               [PsyQuiz](https://countrycode.xyz/api)               | Psychological assessment API with 8 frameworks (Big Five, Attachment, CBT, Flow, etc.) |    No    |  Yes  |   Yes   |
 | [Quote Garden](https://pprathameshmore.github.io/QuoteGarden/)  | REST API for more than 5000 famous quotes                              |    No    |  Yes  | Unknown |
 |        [Quoterism](https://www.quoterism.com/developer)         | Inspirational Quotes                                                   |    No    |  Yes  | Unknown |
 |       [Quotes on Design](https://quotesondesign.com/api/)       | Inspirational Quotes                                                   |    No    |  Yes  | Unknown |

--- a/README.md
+++ b/README.md
@@ -816,7 +816,7 @@
 |            [Meme](https://github.com/D3vd/Meme_Api)             | JSON API for a random meme scraped from reddit                         |    No    |  Yes  | Unknown |
 |        [NaMoMemes](https://github.com/theIYD/NaMoMemes)         | Memes on Narendra Modi                                                 |    No    |  Yes  | Unknown |
 | [Programming Quotes](https://programming-quotesapi.vercel.app/) | An api which generates quotes from programmers                         |    No    |  Yes  |   Yes   |
-|               [PsyQuiz](https://countrycode.xyz/api)               | Psychological assessment API with 8 frameworks (Big Five, Attachment, CBT, Flow, etc.) |    No    |  Yes  |   Yes   |
+|               [PsyQuiz](https://psy.oneroad.com/api)               | Psychological assessment API with 8 frameworks (Big Five, Attachment, CBT, Flow, etc.) |    No    |  Yes  |   Yes   |
 | [Quote Garden](https://pprathameshmore.github.io/QuoteGarden/)  | REST API for more than 5000 famous quotes                              |    No    |  Yes  | Unknown |
 |        [Quoterism](https://www.quoterism.com/developer)         | Inspirational Quotes                                                   |    No    |  Yes  | Unknown |
 |       [Quotes on Design](https://quotesondesign.com/api/)       | Inspirational Quotes                                                   |    No    |  Yes  | Unknown |


### PR DESCRIPTION
## Add PsyQuiz API 🧠

[PsyQuiz](https://psy.onceroad.com/api) is a free, open-source psychological assessment API with **8 frameworks**:

- **Big Five Personality** (25-question OCEAN model with Likert
