### PR TITLE
Add The Calendar API

### DIFF
--- a/README.md
+++ b/README.md
@@ -165,6 +165,7 @@
 |               [Non-Working Days ICS](https://github.com/gadael/icsdb)               | Database of ICS files for non working days                                                             |    No    |  Yes  | Unknown |
 |              [OpenHolidays API](https://www.openholidaysapi.org/)               | Public and school holidays for many countries via an open REST API                                     |    No    |  Yes  |   Yes   |
 |            [Russian Calendar](https://github.com/egno/work-calendar)            | Check if a date is a Russian holiday or not                                                            |    No    |  Yes  |   No    |
+| [The Calendar](https://the-calendar.net/api/) | Public holidays for US states and 30 countries plus sports and finance calendars as static JSON | No | Yes | Yes |
 |      [TimeZones iCal Library](https://tz.add-to-calendar-technology.com/)       | Database of official time zones and corresponding iCal VTIMEZONE blocks                                |    No    |  Yes  | Unknown |
 
 **[⬆ Back to Index](#index)**


### PR DESCRIPTION
## Type of Change

- [x] Adding a new API entry
- [ ] Fixing a broken link
- [ ] Updating an existing entry
- [ ] Documentation / formatting fix
- [ ] Other (please describe):

## Checklist

- [x] Entry format: `| [Name](URL) | Description | Auth | HTTPS | CORS |`
- [x] Auth value is one of: `No`, `apiKey`, `OAuth`, `X-Mashape-Key`
- [x] HTTPS value is `Yes` or `No`
- [x] CORS value is `Yes`, `No`, or `Unknown`
- [x] Description does **not** end with punctuation
- [x] Entry is placed in **alphabetical order** within the correct section
- [x] Each table column is padded with one space on either side
- [x] I have **not removed** any existing entries
- [x] I have searched the list for duplicates (same API name or URL)
- [x] The API link is working and returns documentation
- [x] All changes have been squashed into a single commit

## API Details

**The Calendar** — free static JSON API for calendar data.

- Endpoint base: https://the-calendar.net/api/
- Manifest (all endpoints): https://the-calendar.net/api/index.json
- Sample: https://the-calendar.net/api/holidays/us-federal/2026.json
- Auth: No · HTTPS: Yes · CORS: Yes (`Access-Control-Allow-Origin: *`)
- No rate limit, no key required
- Coverage: US federal holidays (2025–2028), all 50 US states, 30 countries, FOMC dates, US tax deadlines, market holidays, sports schedules
- Licence: CC BY 4.0