### PR TITLE
Add Amazon Scraper API to Shopping

### DIFF
--- a/README.md
+++ b/README.md
@@ -892,6 +892,7 @@
 
 |                                  API                                  | Description                                                                |   Auth   | HTTPS |  CORS   |
 | :-------------------------------------------------------------------: | -------------------------------------------------------------------------- | :------: | :---: | :-----: |
+| [Amazon Scraper API](https://docs.amazonscraperapi.com) | Amazon product, search and batch ASIN data across 20 marketplaces | `apiKey` | Yes | No |
 | [Best Buy](https://bestbuyapis.github.io/api-documentation/#overview) | Products, Buying Options, Categories, Recommendations, Stores and Commerce | `apiKey` |  Yes  | Unknown |
 |                [eBay](https://go.developer.ebay.com/)                 | Sell and Buy on eBay                                                       | `OAuth`  |  Yes  | Unknown |
 |          [ShopSavvy](https://shopsavvy.com/data)                      | Product pricing and price history across thousands of retailers             | `apiKey` |  Yes  |   Yes   |


### PR DESCRIPTION
**What is this project?**
Amazon Scraper API is a managed REST API for scraping Amazon product detail pages, search results, and batch ASIN lookups across 20 marketplaces. Returns clean JSON (title, price, rating, reviews, brand, availability, variants).

**Why it fits the Shopping section?**
The existing Shopping entries cover other retailers (Best Buy, eBay) and cross-retailer product pricing (ShopSavvy). Amazon Scraper API is the Amazon-specific equivalent: a developer REST API for product data, alphabetically positioned before Best Buy.

**Format compliance**
- [x] 5-column table format
- [x] Alphabetical order (inserted before Best Buy at top of section)
- [x] Auth: `apiKey` (X-API-Key header, valid value)
- [x] HTTPS: Yes
- [x] CORS: No (server-side only)
- [x] Description does not end with punctuation
- [x] No duplicate (not currently in any section)
- [x] HTTPS link to documentation

**Free for use?**
Yes: 1000 free requests on signup, plus a free /asin-lookup tool. The endpoint and documentation are publicly accessible without payment, which is the standard for entries like Best Buy and eBay that also require a key for free-tier access.