### PR TITLE
Add Pharos API (Cryptocurrency)

### DIFF
--- a/README.md
+++ b/README.md
@@ -226,6 +226,7 @@
 |               [MEXC Global](https://www.mexc.com/mexc-api)               | Crypto asset exchange for trading Marketplace                                                                                      | `apiKey` |  Yes  | Unknown |
 |             [Nexchange](https://nexchange2.docs.apiary.io/)              | Automated cryptocurrency exchange service                                                                                          |    No    |  No   |   Yes   |
 |                  [NiceHash](https://docs.nicehash.com/)                  | Largest Crypto Mining Marketplace                                                                                                  | `apiKey` |  Yes  | Unknown |
+| [Pharos API](https://pharos.watch/about/api/) | Stablecoin risk, peg, liquidity, safety score, blacklist, mint/burn, yield, and chain-health data | `apiKey` | Yes | Unknown |
 |              [Poloniex](https://api-docs.poloniex.com/spot)              | US based digital asset exchange                                                                                                    | `apiKey` |  Yes  | Unknown |
 |       [WorldCoinIndex](https://www.worldcoinindex.com/apiservice)        | Cryptocurrencies Prices                                                                                                            | `apiKey` |  Yes  | Unknown |
 


### PR DESCRIPTION
Adds Pharos API to the Cryptocurrency category — a stablecoin analytics
dashboard providing market data, risk scores, peg stability, liquidity
metrics, safety scores, blacklist tracking, mint/burn flows, yield
intelligence, and chain-health data.

- Name: Pharos API
- URL: https://pharos.watch/about/api/
- Base URL: https://api.pharos.watch
- Auth: API Key (apiKey)
- HTTPS: Yes
- CORS: Unknown

Checklist:
- Entry is in alphabetical order (between NiceHash and Poloniex)
- Description does not end with punctuation
- Auth field uses accepted value (apiKey)
- No duplicate API name or URL