### PR TITLE
Add GetXAPI to Social section

### DIFF
--- a/README.md
+++ b/README.md
@@ -908,6 +908,7 @@
 |              [Facebook](https://developers.facebook.com/)              | Facebook Login, Share on FB, Social Plugins, Analytics and more                                   | `OAuth`  |  Yes  | Unknown |
 |            [Foursquare](https://developer.foursquare.com/)             | Interact with Foursquare users and places (geolocation-based checkins, photos, tips, events, etc) | `OAuth`  |  Yes  | Unknown |
 |      [Full Contact](https://www.fullcontact.com/developer/docs/)       | Get Social Media profiles and contact Information                                                 | `OAuth`  |  Yes  | Unknown |
+|              [GetXAPI](https://docs.getxapi.com)               | Twitter scraping and posting API with 44 endpoints from $0.001 per call                            | `apiKey` |  Yes  |   No    |
 |            [HackerNews](https://github.com/HackerNews/API)             | Social news for CS and entrepreneurship                                                           |    No    |  Yes  | Unknown |
 |           [Instagram](https://www.instagram.com/developer/)            | Instagram Login, Share on Instagram, Social Plugins and more                                      | `OAuth`  |  Yes  | Unknown |
 |                 [MySocialApp](https://mysocialapp.io)                  | Seamless Social Networking features, API, SDK to any app                                          | `apiKey` |  Yes  | Unknown |


### PR DESCRIPTION
## Type of Change

- [x] Adding a new API entry

## API Details

**API Name:** GetXAPI  
**Category/Section:** Social  
**Auth:** `apiKey`  
**HTTPS:** Yes  
**CORS:** No

## Description

[GetXAPI](https://docs.getxapi.com) is a Twitter/X scraping and posting API with 44 endpoints — tweet search, user lookup, followers/following, timelines, replies, DMs, create/like/retweet tweets, and articles. Free tier on signup ($0.1 in credits, no credit card), then pay-as-you-go from $0.001 per call.

- **Docs**: https://docs.getxapi.com
- **OpenAPI spec**: https://docs.getxapi.com/openapi.json
- **Free tier**: $0.1 free credits on signup

## Contribution checklist

- [x] Submission is formatted per [CONTRIBUTING](.github/CONTRIBUTING.md)
- [x] Addition is in alphabetical order (between `Full Contact` and `HackerNews`)
- [x] Description does not end with punctuation
- [x] Table columns padded with one space on either side
- [x] Auth value is from accepted list (`apiKey`)
- [x] CORS value is from accepted list (`No`)
- [x] Searched for duplicates