### PR TITLE
Add BrewPage to Cloud Storage & File Sharing

### DIFF
--- a/README.md
+++ b/README.md
@@ -176,6 +176,7 @@
 |                         API                          | Description              |   Auth   | HTTPS |  CORS   |
 | :--------------------------------------------------: | ------------------------ | :------: | :---: | :-----: |
 |          [Box](https://developer.box.com/)           | File Sharing and Storage | `OAuth`  |  Yes  | Unknown |
+| [BrewPage](https://kochetkov-ma.github.io/brewpage-openapi/) | Free HTML/Markdown/KV/JSON/file hosting with short URLs | No | Yes | Yes |
 |    [Dropbox](https://www.dropbox.com/developers)     | File Sharing and Storage | `OAuth`  |  Yes  | Unknown |
 | [Google Drive](https://developers.google.com/drive/) | File Sharing and Storage | `OAuth`  |  Yes  | Unknown |
 |        [Mega.nz](https://mega.io/developers)         | File Sharing And Storage |    No    |  Yes  | Unknown |


### PR DESCRIPTION
Adds BrewPage to the **Cloud Storage & File Sharing** section.

| API | Description | Auth | HTTPS | CORS |
| --- | --- | --- | --- | --- |
| [BrewPage](https://kochetkov-ma.github.io/brewpage-openapi/) | Free HTML/Markdown/KV/JSON/file hosting with short URLs | No | Yes | Yes |

BrewPage is a free hosting platform (`https://brewpage.app`) for HTML/Markdown content, key-value entries, JSON documents, and arbitrary files. The public REST API requires no authentication for reads; writes use owner tokens returned by the publish endpoints. OpenAPI 3.1 spec at `https://kochetkov-ma.github.io/brewpage-openapi/openapi.json`. MIT-licensed.

Entry inserted alphabetically between Box and Dropbox. Passes `validate_pr.py` and `sort_entries.py` locally.