### PR TITLE
Add TideTurtle to Environment

### DIFF
--- a/README.md
+++ b/README.md
@@ -445,6 +445,7 @@
 |                                     [AQICN](http://aqicn.org/api)                                      | Real-time air quality index                                                       | `apiKey` |  No   | Unknown |
 |                                   [OpenAQ](https://docs.openaq.org/)                                   | Open air quality data                                                             | `apiKey` |  Yes  | Unknown |
 |                      [PVWatts](https://developer.nrel.gov/docs/solar/pvwatts/v6/)                      | Energy production photovoltaic (PV) energy systems                                | `apiKey` |  Yes  | Unknown |
+|                              [TideTurtle](https://tideturtle.com/developers)                              | Tide times + charts for 1,414 coastal places worldwide, REST + MCP server      |    No    |  Yes  |   Yes   |
 | [UK Carbon Intensity](https://carbon-intensity.github.io/api-definitions/#carbon-intensity-api-v1-0-0) | The Official Carbon Intensity API for Great Britain developed by National Grid    |    No    |  Yes  | Unknown |
 |                         [WeatherStack](https://weatherstack.com/documentation)                         | Humidity & Air & Pressure API                                                     | `apiKey` |  Yes  | Unknown |
 |                     [ZipCheckup](https://api.zipcheckup.com/v1)                                        | U.S. drinking water quality data by ZIP code from EPA and 20+ federal sources     |    No    |  Yes  |   Yes   |


### PR DESCRIPTION
Adds **TideTurtle** to the Environment section.

- **URL:** https://tideturtle.com/developers
- **What:** Tide times + tide charts for 1,414 coastal places worldwide. REST API + MCP server.
- **Auth:** None
- **HTTPS:** Yes
- **CORS:** Yes
- **Sources:** NOAA CO-OPS, UK Environment Agency Flood, BSH (Germany), Open-Meteo Marine
- **OpenAPI spec:** https://tideturtle.com/api/v1/openapi.json

Inserted alphabetically in Environment between `PVWatts` and `UK Carbon Intensity`.