### PR TITLE
Add Padel Snipe World Atlas to Sports & Fitness

### DIFF
--- a/README.md
+++ b/README.md
@@ -992,6 +992,7 @@
 |           [JCDecaux Bike](https://developer.jcdecaux.com/)            | JCDecaux's self-service bicycles                                                            |    `apiKey`     |  Yes  | Unknown |
 | [NBA Stats](https://any-api.com/nba_com/nba_com/docs/API_Description) | Current and historical NBA Statistics                                                       |       No        |  Yes  | Unknown |
 |       [NHL Records and Stats](https://gitlab.com/dword4/nhlapi)       | NHL historical data and statistics                                                          |       No        |  Yes  | Unknown |
+|        [Padel Snipe World Atlas](https://padelsnipe.com/world)        | 4,000+ padel clubs across 9 European countries with GPS, court counts, and platform info — CC-BY 4.0 |       No        |  Yes  |   Yes   |
 |               [PropLine](https://prop-line.com)                | Real-time player-props betting odds with graded prop resolution across 13 books incl. Pinnacle |    `apiKey`     |  Yes  | Unknown |
 |               [SharpAPI](https://docs.sharpapi.io)                | Real-time sports betting odds from 20+ sportsbooks with +EV detection                      |    `apiKey`     |  Yes  |   Yes   |
 |                [Strava](https://strava.github.io/api/)                | Connect with athletes, activities and more                                                  |     `OAuth`     |  Yes  | Unknown |


### PR DESCRIPTION
## API

**Padel Snipe World Atlas** — Open API listing every mapped padel club across Europe.

- **Endpoint** : https://padelsnipe.com/api/world/clubs
- **Docs** : https://padelsnipe.com/world/api
- **Visualization** : https://padelsnipe.com/world
- **License** : CC-BY 4.0
- **Officially listed on** : data.gouv.fr — https://www.data.gouv.fr/datasets/atlas-des-clubs-de-padel-base-de-donnees-ouverte-cc-by-4-0/

## Specs

| Property | Value |
|---|---|
| Auth | No |
| HTTPS | Yes |
| CORS | Yes |
| Pagination | No (single JSON response, ~600 KB gzipped) |
| Rate limit | None published, CDN-cached 24h |

## Content

~4,000 padel clubs across 9 European countries (ES, IT, FR, UK, DE, BE, PT, NL, SE). Each record :

- GPS coordinates (latitude, longitude WGS84)
- Club name, city, postal code
- Indoor / outdoor court counts
- Booking platform (Playtomic or Anybuddy)
- Release pattern observation (when each club opens its booking slots)

## Why it fits Sports & Fitness

Padel is the fastest-growing racket sport in Europe. No equivalent public dataset exists today — data was fragmented across booking platforms. The list already has entries for golf (Golf-Data, DiscGolf), tennis-adjacent sports (Strava), football, etc.

## Insertion

Alphabetically between **NHL Records and Stats** and **PropLine** in the Sports & Fitness section. Single-line table entry, no other changes.