### PR TITLE
Add Neotimo DGFiP Mirror to Government

### DIFF
--- a/README.md
+++ b/README.md
@@ -672,6 +672,7 @@
 |                     [FEC](https://api.open.fec.gov/developers/)                     | Information on campaign donations in federal elections                                    | `apiKey` |  Yes  | Unknown |
 | [Federal Register](https://www.federalregister.gov/reader-aids/developer-resources) | The Daily Journal of the United States Government                                         |    No    |  Yes  | Unknown |
 | [Japan Neighborhoods](https://japanneighborhoods.com/developers) | Tokyo neighborhood crime statistics, safety scores, and station data (5,078 areas, 2018-2024) |    No    |  Yes  |   Yes   |
+| [Neotimo DGFiP Mirror](https://neotimo.com/annuaire-dgfip) | French DGFiP registry of certified e-invoicing platforms (Plateformes Agréées), searchable by SIRET | No | Yes | Unknown |
 |               [Open Government, Australia](https://www.data.gov.au/)                | Australian Government Open Data                                                           |    No    |  Yes  | Unknown |
 |                  [Open Government, Belgium](https://data.gov.be/)                   | Belgium Government Open Data                                                              |    No    |  Yes  | Unknown |
 |                 [Open Government, Canada](http://open.canada.ca/en)                 | Canadian Government Open Data                                                             |    No    |  No   | Unknown |


### PR DESCRIPTION
Adds **Neotimo DGFiP Mirror** to the Government section.

It's a free public mirror of the French DGFiP registry of *Plateformes Agréées* — the platforms certified for electronic invoicing, which becomes mandatory in France from September 2026.

- No authentication
- Search by SIRET / SIREN
- REST API, 10 requests/min/IP
- Daily sync with the official DGFiP data

One entry added, alphabetical ordering within the section preserved.
