### PR TITLE
Add caldays (public holidays for 195+ countries)

### DIFF
--- a/README.md
+++ b/README.md
@@ -167,6 +167,7 @@
 | :-----------------------------------------------------------------------------: | ------------------------------------------------------------------------------------------------------ | :------: | :---: | :-----: |
 |       [Abstract's Holiday API](https://www.abstractapi.com/holidays-api)        | National, regional, and religious holidays for 120+ countries & 100+ years                             | `apiKey` |  Yes  |   Yes   |
 | [Byabbe](https://byabbe.se/on-this-day/#/default/get__month___day__events_json) | Seach histories from wikipedia for a particular day                                                    |    No    |  Yes  | Unknown |
+| [caldays](https://caldays.com/api) | Public holidays for 195+ countries | No | Yes | Yes |
 |                [Calendar Index](https://www.calendarindex.com/)                 | Worldwide Holidays and Working Days                                                                    | `apiKey` |  Yes  |   Yes   |
 |              [Czech Namedays Calendar](http://svatky.adresa.info/)              | Lookup for a name and returns nameday date                                                             |    No    |  No   | Unknown |
 |              [Feriados API](https://feriadosapi.com)               | Brazilian holidays API covering national, state, and municipal holidays for 5,570+ municipalities      | `apiKey` |  Yes  |   Yes   |


### PR DESCRIPTION
Adds **caldays** to Calendar (alphabetical order). Free public-holiday data — no auth/key, HTTPS, JSON, CORS enabled. Example: https://caldays.com/api/holidays/us · Docs: https://caldays.com/api