### PR TITLE
Add PixelGamesHub AI Games Index to Games & Comics

### DIFF
--- a/README.md
+++ b/README.md
@@ -555,6 +555,7 @@
 |                         [mod.io](https://docs.mod.io)                         | Cross Platform Mod API                                                                                       |    `apiKey`     |  Yes  | Unknown |
 |               [Open Trivia](https://opentdb.com/api_config.php)               | Trivia Questions                                                                                             |       No        |  Yes  | Unknown |
 |                    [PandaScore](https://api.pandascore.co)                    | E-sports games and results                                                                                   |    `apiKey`     |  Yes  | Unknown |
+| [PixelGamesHub AI Games Index](https://pixelgameshub.com/api/ai-games/index.json) | Curated index of AI-powered browser games as JSON and CSV with a published JSON Schema | No | Yes | Yes |
 |        [PlayerUnknown's Battlegrounds](https://tracker.gg/developers)         | PUBG Stats                                                                                                   |    `apiKey`     |  Yes  | Unknown |
 | [Pokemon Price Tracker](https://www.pokemonpricetracker.com/pokemon-card-price-api) | Real-time and historical Pokemon card pricing from TCGPlayer and eBay graded sales | `apiKey` | Yes | Yes |
 |                         [Pokéapi](https://pokeapi.co)                         | Pokémon Information                                                                                          |       No        |  Yes  | Unknown |


### PR DESCRIPTION
## Type of Change
- [x] Adding a new API entry

## Checklist
- [x] Entry format: `| [Name](URL) | Description | Auth | HTTPS | CORS |`
- [x] Auth value is `No`
- [x] HTTPS value is `Yes`
- [x] CORS value is `Yes`
- [x] Description does **not** end with punctuation
- [x] Entry is placed in **alphabetical order** (between PandaScore and PlayerUnknown's)
- [x] Each table column is padded with one space on either side
- [x] I have **not removed** any existing entries
- [x] I searched for duplicates — none
- [x] The API link is working and returns JSON + a published JSON Schema
- [x] Single squashed commit

## API Details
**API Name:** PixelGamesHub AI Games Index
**Category/Section:** Games & Comics
**Why this API is useful:** A free, no-auth, CORS-enabled API serving a curated index of AI-powered browser games as JSON (https://pixelgameshub.com/api/ai-games/index.json) and CSV (https://pixelgameshub.com/api/ai-games/index.csv), with a published JSON Schema for consumers. Ran `sort_entries.py` and `validate_pr.py` locally — all checks pass.