### PR TITLE
Add US Federal Contracts & Grants API

### DIFF
--- a/README.md
+++ b/README.md
@@ -690,6 +690,7 @@
 |             [Represent by Open North](https://represent.opennorth.ca/)              | Find Canadian Government Representatives                                                  |    No    |  Yes  | Unknown |
 |               [State, New York State Opendata] (https://data.ny.gov/)               | New York State Open Data                                                                  | `OAuth`  |  Yes  | Unknown |
 |         [US Federal Contracts & Grants](https://government-data-api.onrender.com/docs)          | US federal contracts, grants, and agency spending data from USASpending.gov               |    No    |  Yes  |   Yes   |
+|             [US Federal Contracts & Grants API](https://government-data-api.onrender.com/docs)             | Access millions of US federal contracts, grants, and agency spending data — updated daily |    No    |  Yes  |   Yes   |
 |                   [USAspending.gov](https://api.usaspending.gov/)                   | US federal spending data                                                                  |    No    |  Yes  | Unknown |
 
 **[⬆ Back to Index](#index)**

--- a/README.md
+++ b/README.md
@@ -690,7 +690,6 @@
 |             [Represent by Open North](https://represent.opennorth.ca/)              | Find Canadian Government Representatives                                                  |    No    |  Yes  | Unknown |
 |               [State, New York State Opendata] (https://data.ny.gov/)               | New York State Open Data                                                                  | `OAuth`  |  Yes  | Unknown |
 |         [US Federal Contracts & Grants](https://government-data-api.onrender.com/docs)          | US federal contracts, grants, and agency spending data from USASpending.gov               |    No    |  Yes  |   Yes   |
-|             [US Federal Contracts & Grants API](https://government-data-api.onrender.com/docs)             | Access millions of US federal contracts, grants, and agency spending data — updated daily |    No    |  Yes  |   Yes   |
 |                   [USAspending.gov](https://api.usaspending.gov/)                   | US federal spending data                                                                  |    No    |  Yes  | Unknown |
 
 **[⬆ Back to Index](#index)**

--- a/README.md
+++ b/README.md
@@ -689,6 +689,7 @@
 |                     [ProcureData](https://procuredata.ca)                           | Canadian federal procurement contracts, tenders and awards                                 | `apiKey` |  Yes  | Unknown |
 |             [Represent by Open North](https://represent.opennorth.ca/)              | Find Canadian Government Representatives                                                  |    No    |  Yes  | Unknown |
 |               [State, New York State Opendata] (https://data.ny.gov/)               | New York State Open Data                                                                  | `OAuth`  |  Yes  | Unknown |
+|         [US Federal Contracts & Grants](https://government-data-api.onrender.com/docs)          | US federal contracts, grants, and agency spending data from USASpending.gov               |    No    |  Yes  |   Yes   |
 |                   [USAspending.gov](https://api.usaspending.gov/)                   | US federal spending data                                                                  |    No    |  Yes  | Unknown |
 
 **[⬆ Back to Index](#index)**


### PR DESCRIPTION
## Add US Federal Contracts & Grants API

Adds Government Contracts & Grants API to the Government section.

- **API**: US Federal Contracts & Grants
- **URL**: https://government-data-api.onrender.com/docs
- **Description**: US federal contracts, grants, and agency spending data from USASpending.gov
- **Auth**: No (free, no API key required)
- **HTTPS**: Yes
- **CORS**: Yes

This API provides programmatic access to millions of US federal government contracts and grants, updated daily from USASpending.gov. Endpoints: /contracts, /grants, /agencies, /health