### PR TITLE
Add Starveri API

### DIFF
--- a/README.md
+++ b/README.md
@@ -743,6 +743,7 @@
 | [Kelly Intelligence](https://api.thedailylesson.com) | OpenAI-compatible AI tutor with 162K vocabulary words across 47 languages | `apiKey` |  Yes  |   Yes   |
 |                  [Kiprio AI Content Detector](https://kiprio.com/ai-detect-api)                   | Detect AI-generated text with per-sentence confidence scoring         | `apiKey` |  Yes  |   Yes   |
 |                         [Replicate](https://replicate.com/docs/reference/http)    | Run and deploy machine learning models in the cloud     | `apiKey` |  Yes  |   Yes   |
+| [Starveri](https://api.starveri.net/docs) | OpenAI-compatible chat completions with free demo credits | `apiKey` | Yes | Yes |
 |                     [Unplugg](https://unplu.gg/test_api.html)                     | Forecasting API for timeseries data                     | `apiKey` |  Yes  | Unknown |
 |                             [Wit.ai](https://wit.ai/)                             | Natural Language Processing                             | `OAuth`  |  Yes  | Unknown |
 


### PR DESCRIPTION
Adds Starveri to the Machine Learning section. Starveri provides OpenAI-compatible chat completions with API-key auth, HTTPS, CORS support, public docs, and free demo credits.\n\nValidation run:\n- py -3 .github/scripts/validate_pr.py\n- py -3 .github/scripts/sort_entries.py --check