### PR TITLE
Add TWZRD Agent Intel to Machine Learning APIs

### DIFF
--- a/README.md
+++ b/README.md
@@ -742,6 +742,7 @@
 |                            [Keen IO](https://keen.io/)                            | Data Analytics                                          | `apiKey` |  Yes  | Unknown |
 | [Kelly Intelligence](https://api.thedailylesson.com) | OpenAI-compatible AI tutor with 162K vocabulary words across 47 languages | `apiKey` |  Yes  |   Yes   |
 |                  [Kiprio AI Content Detector](https://kiprio.com/ai-detect-api)                   | Detect AI-generated text with per-sentence confidence scoring         | `apiKey` |  Yes  |   Yes   |
+| [TWZRD Agent Intel](https://intel.twzrd.xyz) | On-chain trust scoring and reputation for AI agent wallets on Solana. Free MCP tools included. | `x402` |  Yes  |   Yes   |
 |                         [Replicate](https://replicate.com/docs/reference/http)    | Run and deploy machine learning models in the cloud     | `apiKey` |  Yes  |   Yes   |
 |                     [Unplugg](https://unplu.gg/test_api.html)                     | Forecasting API for timeseries data                     | `apiKey` |  Yes  | Unknown |
 |                             [Wit.ai](https://wit.ai/)                             | Natural Language Processing                             | `OAuth`  |  Yes  | Unknown |


### PR DESCRIPTION
Add [TWZRD Agent Intel](https://intel.twzrd.xyz) to the Machine Learning section.

**TWZRD Agent Intel** is an on-chain trust scoring API and MCP server for AI agent wallets on Solana:
- `score_agent(wallet)` — free reputation score (0-100) based on on-chain history
- `preflight_check(wallet)` — free go/no-go signal before x402 micropayments  
- `get_trust_receipt(wallet)` — paid (x402 micropayment) signed trust receipt

**MCP endpoint**: `https://intel.twzrd.xyz/mcp` (streamable-http)
**Auth**: x402 micropayment (free tools available)
**HTTPS**: Yes | **CORS**: Yes
