### PR TITLE
Add World Cup 2026 Tour API

### DIFF
--- a/README.md
+++ b/README.md
@@ -997,6 +997,7 @@
 |                [Strava](https://strava.github.io/api/)                | Connect with athletes, activities and more                                                  |     `OAuth`     |  Yes  | Unknown |
 |          [TheSportsDB](https://www.thesportsdb.com/api.php)           | Crowd-Sourced Sports Data and Artwork                                                       |    `apiKey`     |  Yes  |   Yes   |
 |                [Wger](https://wger.de/en/software/api)                | Workout manager data as exercises, muscles or equipment                                     |    `apiKey`     |  Yes  | Unknown |
+|       [World Cup 2026 Tour](https://ay-worldcup2026.zeabur.app/developers)       | World Cup 2026 fixtures with optional local-time conversion                                  |       No        |  Yes  |   Yes   |
 
 **[⬆ Back to Index](#index)**
 


### PR DESCRIPTION
## Summary

Adds World Cup 2026 Tour to the Sports & Fitness category.

## API details

- Free World Cup 2026 fixtures API
- No authentication required
- HTTPS supported
- CORS supported (`Access-Control-Allow-Origin: *`)
- Documentation: https://ay-worldcup2026.zeabur.app/developers
- Metadata endpoint: https://ay-worldcup2026.zeabur.app/api/public/v1/metadata

## Validation

- `python3 .github/scripts/validate_pr.py` passed
- `python3 .github/scripts/sort_entries.py --check` passed
- Verified production documentation and metadata endpoints return HTTP 200