### PR TITLE
Add UTM parameters to Atlas Cloud sponsor links

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,11 +43,11 @@
 
 <!-- Silver sponsors get a logo + one-line description -->
 
-<a href="https://www.atlascloud.ai/">
+<a href="https://www.atlascloud.ai/?utm_source=github&utm_medium=link&utm_campaign=public-api-lists">
   <img src="assets/atlas-cloud.png" width="150" alt="Atlas Cloud">
 </a>
 
-**[Atlas Cloud](https://www.atlascloud.ai/)** — AI API aggregation platform with OpenAI-compatible chat completions, image and video generation
+**[Atlas Cloud](https://www.atlascloud.ai/?utm_source=github&utm_medium=link&utm_campaign=public-api-lists)** — AI API aggregation platform with OpenAI-compatible chat completions, image and video generation
 
 ### 🥉 Bronze Sponsors
 


### PR DESCRIPTION
## Summary

- Atlas Cloud 이미지 링크에 UTM 파라미터 추가 (`utm_source=github&utm_medium=link&utm_campaign=public-api-lists`)
- Atlas Cloud 텍스트 링크에도 동일한 UTM 파라미터 추가

## Test plan

- [ ] README에서 Atlas Cloud 이미지 클릭 시 UTM 파라미터가 포함된 URL로 이동하는지 확인
- [ ] README에서 Atlas Cloud 텍스트 링크 클릭 시 동일하게 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)