### PR TITLE
Add Folderwijzer Folder API (Dutch store folders)

### DIFF
--- a/README.md
+++ b/README.md
@@ -937,6 +937,7 @@
 | [Amazon Scraper API](https://docs.amazonscraperapi.com) | Amazon product, search and batch ASIN data across 20 marketplaces | `apiKey` | Yes | No |
 | [Best Buy](https://bestbuyapis.github.io/api-documentation/#overview) | Products, Buying Options, Categories, Recommendations, Stores and Commerce | `apiKey` |  Yes  | Unknown |
 |                [eBay](https://go.developer.ebay.com/)                 | Sell and Buy on eBay                                                       | `OAuth`  |  Yes  | Unknown |
+| [Folderwijzer Folders](https://folderwijzer.nl/folder-api/) | Dutch store folders currently running, with each folder's validity dates and a deeplink (beer & wine) | No | Yes | Unknown |
 |          [ShopSavvy](https://shopsavvy.com/data)                      | Product pricing and price history across thousands of retailers             | `apiKey` |  Yes  |   Yes   |
 
 **[⬆ Back to Index](#index)**


### PR DESCRIPTION
Adds one entry under Shopping (alphabetical, after eBay).

Folderwijzer publishes a free JSON feed of Dutch store folders (reclamefolders) that are live right now: store name, the start and end date of each folder, and a deeplink. Scope is beer and wine. No key, no login, HTTPS only.

- Docs: https://folderwijzer.nl/folder-api/
- Feed: https://folderwijzer.nl/api/v1/folders.json

It returns folder timing and deeplinks, not per-product prices. One link, sorted alphabetically.