### PR TITLE
Add InfraNode API

### DIFF
--- a/README.md
+++ b/README.md
@@ -803,6 +803,7 @@
 |     [Enigma Public](http://docs.enigma.com/public/public_v20_api_about)     | Broadest collection of public data                                                                 | `apiKey` |  Yes  |   Yes   |
 |          [French Address Search](https://geo.api.gouv.fr/adresse)           | Address search via the French Government                                                           |    No    |  Yes  | Unknown |
 |              [Fruits](https://fruits-api.netlify.app/graphql)               | Information of fruit trees of the world                                                            |    No    |  Yes  |   No    |
+| [InfraNode](https://infranode.dev) | Unified German city open data: weather, air quality, EV chargers, transit, demographics | `apiKey` | Yes | Unknown |
 |                 [LinkPreview](https://www.linkpreview.net)                  | Get JSON formatted summary with title, description and preview image for any requested URL         | `apiKey` |  Yes  |   Yes   |
 |                    [Microlink.io](https://microlink.io)                     | Extract structured data from any website                                                           |    No    |  Yes  |   Yes   |
 | [OpenCorporates](http://api.opencorporates.com/documentation/API-Reference) | Data on corporate entities and directors in many countries                                         | `apiKey` |  Yes  | Unknown |


### PR DESCRIPTION
Adds InfraNode to the Open Data section (alphabetically between Fruits and LinkPreview).

- Link: https://infranode.dev
- Unified German city open data (weather, air quality, EV chargers, transit, demographics) from 35+ official sources, one consistent JSON envelope, per-record license attribution.
- Auth: apiKey (optional; anonymous at 60 req/min)
- HTTPS: Yes, CORS: Unknown

Single entry.