### PR TITLE
Add Agent Toolbelt to Finance

### DIFF
--- a/README.md
+++ b/README.md
@@ -467,6 +467,7 @@
 
 |                                   API                                    | Description                                                   |   Auth   | HTTPS |  CORS   |
 | :----------------------------------------------------------------------: | ------------------------------------------------------------- | :------: | :---: | :-----: |
+| [Agent Toolbelt](https://www.agenttoolbelt.live) | AI-generated stock analysis (investment thesis, valuation, insider signal, earnings) from live fundamentals, as structured JSON | `apiKey` | Yes | Unknown |
 |              [Alpha Vantage](https://www.alphavantage.co/)               | Realtime and historical stock data                            | `apiKey` |  Yes  | Unknown |
 |        [Barchart OnDemand](https://www.barchartondemand.com/free)        | Stock, Futures and Forex Market Data                          | `apiKey` |  Yes  | Unknown |
 |           [CommodityPriceAPI](https://commoditypriceapi.com/)            | Real-time & historical commodity prices (metals, energy, etc) | `apiKey` |  Yes  | Unknown |


### PR DESCRIPTION
Adds Agent Toolbelt to the Finance section.

- **Auth:** apiKey · **HTTPS:** Yes · **CORS:** Unknown
- Free tier available (no credit card)
- Alphabetical placement (before Alpha Vantage)

Agent Toolbelt is an AI stock-research API: it returns structured *analysis* (investment thesis, valuation verdict, insider signal, earnings) generated from live fundamentals, rather than raw market data.