### PR TITLE
Add PixelVault to Photography

### DIFF
--- a/README.md
+++ b/README.md
@@ -879,6 +879,7 @@
 |          [ObjectCut](https://objectcut.com/)          | Image Background removal                                   | `apiKey` |  Yes  |   Yes   |
 |         [Pexels](https://www.pexels.com/api/)         | Free Stock Photos and Videos                               | `apiKey` |  Yes  |   Yes   |
 | [Pixabay](https://pixabay.com/sk/service/about/api/)  | Photography                                                | `apiKey` |  Yes  | Unknown |
+| [PixelVault](https://pixelvault.dev/docs) | Agent-first image hosting with instant CDN URLs | `apiKey` | Yes | No |
 |        [PlaceKitten](https://placekitten.com/)        | Resizable kitten placeholder images                        |    No    |  Yes  | Unknown |
 |    [ScreenShotLayer](https://screenshotlayer.com)     | URL 2 Image                                                |    No    |  Yes  | Unknown |
 |      [Unsplash](https://unsplash.com/developers)      | Photography                                                | `OAuth`  |  Yes  | Unknown |


### PR DESCRIPTION
Adds PixelVault — agent-first image hosting with instant CDN URLs. apiKey auth, HTTPS.