### PR TITLE
Add Xquik to Social APIs

### DIFF
--- a/README.md
+++ b/README.md
@@ -970,6 +970,7 @@
 |            [Twitter](https://developer.twitter.com/en/docs)            | Read and write Twitter data                                                                       | `OAuth`  |  Yes  |   No    |
 |                  [TwitterApi](http://twitterapi.io/)                   | Mass Twitter data read API                                                                        | `apiKey` |  Yes  |   No    |
 |                     [vk](https://vk.com/dev/sites)                     | Read and write vk data                                                                            | `OAuth`  |  Yes  | Unknown |
+|       [Xquik](https://docs.xquik.com/api-reference/overview)           | X/Twitter data for tweets, profiles, search, and trends                                           | `apiKey` |  Yes  | Unknown |
 
 **[⬆ Back to Index](#index)**
 


### PR DESCRIPTION
## Summary
- Add Xquik to the Social API table
- Link to the public API docs and mark authentication as apiKey

## Validation
- sort_entries.py
- validate_pr.py
- whitespace diff check
- docs link returned HTTP 200