### PR TITLE
Add AllRatesToday to Currency Exchange

### DIFF
--- a/README.md
+++ b/README.md
@@ -248,6 +248,7 @@
 |                                                     API                                                      | Description                                                        |   Auth   | HTTPS |  CORS   |
 | :----------------------------------------------------------------------------------------------------------: | ------------------------------------------------------------------ | :------: | :---: | :-----: |
 |                        [1Forge](https://1forge.com/forex-data-api/api-documentation)                         | Forex currency market data                                         | `apiKey` |  Yes  | Unknown |
+|                              [AllRatesToday](https://allratestoday.com)                                       | Real-time mid-market exchange rates for 160+ currencies with SDKs   | `apiKey` |  Yes  | Unknown |
 |                              [Coinnect](https://coinnect.bot/docs)                                           | Open money transfer routing across fiat, crypto and P2P networks   | `apiKey` |  Yes  |   Yes   |
 |                                [CurrencyFreaks](https://currencyfreaks.com/)                                 | Currency conversion with latest & historical forex exchange rates  | `apiKey` |  Yes  | Unknown |
 |                           [Currencylayer](https://currencylayer.com/documentation)                           | Exchange rates and currency conversion                             | `apiKey` |  Yes  | Unknown |


### PR DESCRIPTION
Adds **AllRatesToday** to the Currency Exchange section.

- **Link:** https://allratestoday.com
- **Description:** Real-time mid-market exchange rates for 160+ currencies with SDKs
- **Auth:** `apiKey` · **HTTPS:** Yes · **CORS:** Unknown

It provides a free tier (no credit card) and official JavaScript, Python, and PHP SDKs. Entry placed alphabetically and follows the existing table format (5 columns).