### PR TITLE
Add Texas Bond Verify API to Government section

### DIFF
--- a/README.md
+++ b/README.md
@@ -689,6 +689,7 @@
 |                     [ProcureData](https://procuredata.ca)                           | Canadian federal procurement contracts, tenders and awards                                 | `apiKey` |  Yes  | Unknown |
 |             [Represent by Open North](https://represent.opennorth.ca/)              | Find Canadian Government Representatives                                                  |    No    |  Yes  | Unknown |
 |               [State, New York State Opendata] (https://data.ny.gov/)               | New York State Open Data                                                                  | `OAuth`  |  Yes  | Unknown |
+|          [Texas Bond Verify](https://verify.quantumsurety.bond)           | Free public API for Texas contractor and notary surety bond compliance; covers 816K+ TDLR-licensed contractors and 66K+ notaries (Quantum Surety Bond Watch) |    No    |  Yes  |   Yes   |
 |                   [USAspending.gov](https://api.usaspending.gov/)                   | US federal spending data                                                                  |    No    |  Yes  | Unknown |
 
 **[⬆ Back to Index](#index)**


### PR DESCRIPTION
## Description

Adds the **Texas Bond Verify** API to the Government section.

**Why it fits:**
- Government data: cross-references Texas TDLR (Dept of Licensing & Regulation) + Texas SOS (Secretary of State) public records
- Free, no auth required — all search endpoints are public, CORS enabled
- 816,247 TDLR contractor records + 66,000+ notary bond records, updated monthly from data.texas.gov
- Already listed in awesomedata/apd-core (merged PR #444) as a Government dataset

**Endpoints:**
- `GET /api/contractor-search?q=&county=&type=` — Search TDLR-licensed contractors by name/county/license type
- `GET /api/search?q=&city=` — Search Texas notary bond status
- `GET /api/v1/status` — Live count (notaries + contractors)
- `GET /api/v1/contractor/lookup/:license_number` — Lookup by license (API key req for v1)

Live API: https://verify.quantumsurety.bond
Published by Quantum Surety Bond Watch (TDI License #3480229)