### PR TITLE
Add PDFFleet API

### DIFF
--- a/README.md
+++ b/README.md
@@ -416,6 +416,7 @@
 | [PaperClean](https://paperclean.ip1.cc/api/docs) | Clean document photos for printing, remove shadows, fix lighting | `apiKey` |  Yes  |   Yes   |
 |                        [PDFBolt](https://pdfbolt.com/docs)                        | HTML to PDF conversion with templates and AI generation        | `apiKey` |  Yes  |   Yes   |
 |                      [pdfEndpoint](https://pdfendpoint.com)                       | HTML or URL to PDF                                             | `apiKey` |  Yes  |   No    |
+|                         [PDFFleet](https://pdffleet.com)                          | HTML and URL to PDF with templates and a free tier             | `apiKey` |  Yes  |   Yes   |
 |                         [pdflayer](https://pdflayer.com)                          | HTML/URL to PDF                                                | `apiKey` |  Yes  | Unknown |
 |                    [Pocket](https://getpocket.com/developer/)                     | Bookmarking service                                            | `OAuth`  |  Yes  | Unknown |
 |                         [PrexView](https://prexview.com)                          | Data from XML or JSON to PDF, HTML or Image                    | `apiKey` |  Yes  | Unknown |


### PR DESCRIPTION
Adds PDFFleet to the Documents & Productivity section.

**PDFFleet** is an HTML and URL to PDF API that renders with headless Chromium. It supports HTML input, URL input, and named templates with JSON data merge. Free tier: 50 PDFs/month (no credit card required).

- Auth: `apiKey`
- HTTPS: Yes
- CORS: Yes
- Free tier available (50 PDFs/month)
- Docs: https://pdffleet.com/docs

Placed alphabetically between pdfEndpoint and pdflayer in Documents & Productivity.