### PR TITLE
Add DC Hub API

### DIFF
--- a/README.md
+++ b/README.md
@@ -444,6 +444,7 @@
 | :----------------------------------------------------------------------------------------------------: | --------------------------------------------------------------------------------- | :------: | :---: | :-----: |
 |                                 [AirVisual](https://airvisual.com/api)                                 | Air quality and weather data                                                      | `apiKey` |  Yes  | Unknown |
 |                                     [AQICN](http://aqicn.org/api)                                      | Real-time air quality index                                                       | `apiKey` |  No   | Unknown |
+| [DC Hub](https://dchub.cloud/playground)                                                               | Live data on data-center facilities, power markets, grid telemetry, and fiber infrastructure |    No    |  Yes  |   Yes   |
 |                                   [OpenAQ](https://docs.openaq.org/)                                   | Open air quality data                                                             | `apiKey` |  Yes  | Unknown |
 |                      [PVWatts](https://developer.nrel.gov/docs/solar/pvwatts/v6/)                      | Energy production photovoltaic (PV) energy systems                                | `apiKey` |  Yes  | Unknown |
 | [UK Carbon Intensity](https://carbon-intensity.github.io/api-definitions/#carbon-intensity-api-v1-0-0) | The Official Carbon Intensity API for Great Britain developed by National Grid    |    No    |  Yes  | Unknown |


### PR DESCRIPTION
Adds **DC Hub** to the **Environment** category — a free-tier API serving live data on data-center facilities, power markets, grid telemetry, and fiber infrastructure across 170+ countries. Fits alongside the existing PVWatts / UK Carbon Intensity energy entries.

- Single category (Environment), alphabetical order (after AQICN, before OpenAQ)
- Free tier: 10 calls/day, no key required → `Auth: No`
- HTTPS `Yes`; CORS verified (`Access-Control-Allow-Origin: *`) → `Yes`
- Factual description, not marketing