### PR TITLE
Add FilingFirehose to Finance

### DIFF
--- a/README.md
+++ b/README.md
@@ -472,6 +472,7 @@
 |           [CommodityPriceAPI](https://commoditypriceapi.com/)            | Real-time & historical commodity prices (metals, energy, etc) | `apiKey` |  Yes  | Unknown |
 | [Congressional Stock Brain](https://congressionalstockbrain.com) | AI-powered tool scoring U.S. STOCK Act lawmaker trade disclosures for retail investors | No | Yes | Yes |
 |             [Earnings Feed](https://earningsfeed.com/api)                | Real-time SEC filings, insider trades, and institutional holdings | `apiKey` |  Yes  |   No    |
+| [FilingFirehose](https://filingfirehose.com) | Structured SEC EDGAR filings with body-text-classified 8-Ks, activist-tagged 13D/G, and ATM-offering detection in S-3 / 424B5 | No | Yes | Yes |
 |               [Financial Data](https://financialdata.net/)               | Stock Market and Financial Data                               | `apiKey` |  Yes  | Unknown |
 |                 [IEX](https://iextrading.com/developer/)                 | Realtime stock data                                           | `apiKey` |  Yes  |   Yes   |
 |                 [IG](https://labs.ig.com/gettingstarted)                 | Spreadbetting and CFD Market Data                             | `apiKey` |  Yes  | Unknown |


### PR DESCRIPTION
Adding [FilingFirehose](https://filingfirehose.com) under **Finance**.

Structured SEC EDGAR filings API with body-text parsing that goes beyond filer-reported items:
- **8-K**: detects suspected misclassifications (cyber language buried under Item 8.01 that should be 1.05, silent officer departures filed under 8.01 instead of 5.02)
- **Schedule 13D/G**: tags activist filers (Saba, Bulldog, Karpus, Icahn, Elliott, Starboard, Pershing, +14 more)
- **S-3 / 424B5**: shelf size, ATM-offering detection, sales-agent extraction

Free public endpoints (no auth):
- `/v1/public/8k` — last 72h
- `/v1/public/13d`
- `/v1/public/atm`
- `/forensic/score?ticker=AAPL` — per-ticker forensic risk grade

CORS verified: `Access-Control-Allow-Origin: *` on all `/v1/public/*` endpoints. HTTPS only.

Entry inserted alphabetically between Earnings Feed and Financial Data. Validator passes locally.
