### PR TITLE
Add SpryTools APIs (screenshot, scraping, email validation)

### DIFF
--- a/README.md
+++ b/README.md
@@ -275,6 +275,7 @@
 |                   [NumValidate](https://numvalidate.com)                    | Open Source phone number validation                                   |    No    |  Yes  | Unknown |
 |                     [numverify](https://numverify.com)                      | Phone number validation                                               |    No    |  Yes  | Unknown |
 |                   [PurgoMalum](http://www.purgomalum.com)                   | Content validator against profanity & obscenity                       |    No    |  No   | Unknown |
+| [SpryTools Email Validation](https://sprytools.com/apis/email-validation) | Syntax + MX + disposable/role-based email validation | `apiKey` | Yes | Unknown |
 | [TaxID](https://www.taxid.dev/docs) | EU VAT number validation with company name and address lookup across 27 member states | `apiKey` | Yes | Unknown |
 |       [Trestle](https://trestleiq.com/phone-validation-api/)                | Validates the phone number and provides phone metadata                | `apiKey` |  Yes  |   Yes   |
 | [US Autocomplete](https://smartystreets.com/docs/cloud/us-autocomplete-api) | Enter address data quickly with real-time address suggestions         | `apiKey` |  Yes  |   Yes   |
@@ -367,6 +368,8 @@
 |                                   [SerpApi](https://serpapi.com/)                                   | Scrape Google and other search engines with a simple API.                                                              |    `apiKey`     |  Yes  |   No    |
 |                          [Shadify](https://github.com/cheatsnake/shadify)                           | Service for generating data and executing logic to create various games and puzzles                 |       No        |  Yes  |   Yes   |
 |                                 [SHOUTCLOUD](http://shoutcloud.io/)                                 | ALL-CAPS AS A SERVICE                                                                               |       No        |  No   | Unknown |
+| [SpryTools Screenshot](https://sprytools.com/apis/screenshot) | Capture full-page or viewport website screenshots (PNG/JPEG/WebP) | `apiKey` | Yes | Unknown |
+| [SpryTools Web Scraping](https://sprytools.com/apis/scraping) | Extract HTML/text/CSS-selector data, Cloudflare-bypass | `apiKey` | Yes | Unknown |
 |                              [SQLable](https://sqlable.com/validator/)                              | Validate SQL query                                                                                  |       No        |  Yes  |   Yes   |
 |                           [StackExchange](https://api.stackexchange.com/)                           | Q&A forum for developers                                                                            |     `OAuth`     |  Yes  | Unknown |
 |                              [Suprsonic](https://suprsonic.ai)                               | Unified agent API: search, scrape, enrich, image gen, TTS, STT, messaging. One key, 20+ capabilities |    `apiKey`     |  Yes  |   Yes   |


### PR DESCRIPTION
## Type of Change

- [x] Adding a new API entry

## What this adds

Three SpryTools APIs, each placed in its existing, most-fitting section and in alphabetical order (additions only, no existing entries changed):

- **Development** — `SpryTools Screenshot`: Capture full-page or viewport website screenshots (PNG/JPEG/WebP)
- **Development** — `SpryTools Web Scraping`: Extract HTML/text/CSS-selector data, Cloudflare-bypass
- **Data Validation** — `SpryTools Email Validation`: Syntax + MX + disposable/role-based email validation

All three offer a **free tier**, support HTTPS, and use an API key for auth. Links resolve to the public docs/landing pages (HTTP 200 verified).

## Checklist

- [x] Entry format: `| [Name](URL) | Description | Auth | HTTPS | CORS |`
- [x] Auth value is `apiKey`
- [x] HTTPS value is `Yes`
- [x] CORS value is `Unknown`
- [x] Descriptions do not end with punctuation
- [x] Entries placed in alphabetical order within the correct section
- [x] No existing entries removed (append-only)
- [x] Searched the list for duplicates (none)
- [x] 2 sections / 3 entries — within PR size limits