### PR TITLE
Add Is It Safe to Travel API

### DIFF
--- a/README.md
+++ b/README.md
@@ -803,6 +803,7 @@
 |     [Enigma Public](http://docs.enigma.com/public/public_v20_api_about)     | Broadest collection of public data                                                                 | `apiKey` |  Yes  |   Yes   |
 |          [French Address Search](https://geo.api.gouv.fr/adresse)           | Address search via the French Government                                                           |    No    |  Yes  | Unknown |
 |              [Fruits](https://fruits-api.netlify.app/graphql)               | Information of fruit trees of the world                                                            |    No    |  Yes  |   No    |
+| [Is It Safe to Travel](https://isitsafetotravel.org/en/api/) | Daily travel-safety scores and 5 risk pillars for 248 countries, from gov advisories and indices | No | Yes | Yes |
 |                 [LinkPreview](https://www.linkpreview.net)                  | Get JSON formatted summary with title, description and preview image for any requested URL         | `apiKey` |  Yes  |   Yes   |
 |                    [Microlink.io](https://microlink.io)                     | Extract structured data from any website                                                           |    No    |  Yes  |   Yes   |
 | [OpenCorporates](http://api.opencorporates.com/documentation/API-Reference) | Data on corporate entities and directors in many countries                                         | `apiKey` |  Yes  | Unknown |


### PR DESCRIPTION
Adds **Is It Safe to Travel** to **Open Data** (alphabetical, between Fruits and LinkPreview).

- Docs: https://isitsafetotravel.org/en/api/ · Data: https://isitsafetotravel.org/scores.json
- Free, no auth, HTTPS, CORS enabled (verified)
- Daily composite travel-safety scores + 5 risk pillars (conflict, crime, health, governance, environment) for 248 countries, from GPI, INFORM, ReliefWeb, GDACS and US/UK/CA/AU government advisories
- Open source: https://github.com/RiccardoDominici/IsItSafeToTravel

Passes .github/scripts/validate_pr.py locally ("All validation checks passed!").