### PR TITLE
Add Watercare IGC (NZ) to Government

### DIFF
--- a/README.md
+++ b/README.md
@@ -690,6 +690,7 @@
 |             [Represent by Open North](https://represent.opennorth.ca/)              | Find Canadian Government Representatives                                                  |    No    |  Yes  | Unknown |
 |               [State, New York State Opendata] (https://data.ny.gov/)               | New York State Open Data                                                                  | `OAuth`  |  Yes  | Unknown |
 |                   [USAspending.gov](https://api.usaspending.gov/)                   | US federal spending data                                                                  |    No    |  Yes  | Unknown |
+| [Watercare IGC (NZ)](https://devstack.co.nz/calculators/watercare-icg) | Auckland water and wastewater Infrastructure Growth Charge calculations | No | Yes | Yes |
 
 **[⬆ Back to Index](#index)**
 


### PR DESCRIPTION
Adds the Watercare IGC (NZ) API to the Government category, placed after USAspending.gov (alphabetical).

Free JSON API that calculates Auckland's Infrastructure Growth Charge, the one-off water/wastewater levy on new dwellings set by Watercare (Auckland's council-owned water utility). No auth, HTTPS, CORS open. Endpoint: GET https://devstack.co.nz/api/icg with query params; docs and an interactive version at the linked page. Single-line change, single commit.