### PR TITLE
Add CVE.report API

### DIFF
--- a/README.md
+++ b/README.md
@@ -916,6 +916,7 @@
 |                                             API                                             | Description                                                                                                                                                          |   Auth   | HTTPS |  CORS   |
 | :-----------------------------------------------------------------------------------------: | -------------------------------------------------------------------------------------------------------------------------------------------------------------------- | :------: | :---: | :-----: |
 | [Blooms](https://blooms-production.up.railway.app/api)  | Distribute keys once for serverless applications | No |  Yes  | No |
+| [CVE.report](https://cve.report/api) | CVE records with NVD KEV and EPSS enrichment | No | Yes | Yes |
 |                              [FishFish](https://fishfish.gg/)                               | A volunteer cybersecurity project focused on providing resources and services that improve safety across Discord                                                     |    No    |  Yes  | Unknown |
 |                     [HaveIBeenPwned](https://haveibeenpwned.com/API/v3)                     | Passwords which have previously been exposed in data breaches                                                                                                        | `apiKey` |  Yes  | Unknown |
 | [Kiprio SSL Inspector](https://kiprio.com/ssl-api) | TLS certificate analysis with protocol matrix, cipher suite and HSTS grading | `apiKey` |  Yes  |   Yes   |


### PR DESCRIPTION
## Type Change
- [x] Adding new API entry
- [ ] Fixing broken link
- [ ] Updating an existing entry
- [ ] Documentation / formatting fix
- [ ] Other (please describe):

## Checklist
- [x] Entry format: `| [Name](URL) | Description | Auth | HTTPS | CORS |`
- [x] Auth value is one of: `No`, `apiKey`, `OAuth`, `X-Mashape-Key`
- [x] HTTPS value `Yes` or `No`
- [x] CORS value `Yes`, `No`, `Unknown`
- [x] Description does **not** end punctuation
- [x] Entry is placed in **alphabetical order** within correct section
- [x] Each table column padded one space on either side
- [x] I have **not removed** any existing entries
- [x] I searched list duplicates (same API name URL)
- [x] API link working returns documentation
- [x] All changes have been [squashed][squash-link] into single commit

## API Details
**API Name:** CVE.report

**Category/Section:** Security

**Why API is useful:** Free unauthenticated JSON CVE records with NVD KEV and EPSS enrichment.

Docs: https://cve.report/api
OpenAPI: https://cve.report/openapi.json
Sample: https://cve.report/api/cve/CVE-2024-3094.json?pretty=1

Related issue: #538

Local checks:
- `python3 .github/scripts/validate_pr.py` passed with one added entry and no warnings
- `git diff --check` passed

[squash-link]: <https://github.com/todotxt/todo.txt-android/wiki/Squash-All-Commits-Related-to-a-Single-Issue-into-a-Single-Commit>