### PR TITLE
Add Bargo Congress Trades API

### DIFF
--- a/README.md
+++ b/README.md
@@ -655,6 +655,7 @@
 | :---------------------------------------------------------------------------------: | ----------------------------------------------------------------------------------------- | :------: | :---: | :-----: |
 |                      [Apiverket](https://apiverket.se/docs)                         | Unified API for Swedish public data — weather, transport, companies, and 30+ agencies     | `apiKey` |  Yes  |   Yes   |
 |                    [Autobahn API](https://autobahn.api.bund.dev)                    | Information about Germany's federal highways like construction sites and traffic jams     |    No    |  Yes  | Unknown |
+|              [Bargo Congress Trades](https://www.bargo.ai/free-apis/congress)       | U.S. Congress STOCK Act stock trades with per-trade performance                           |    No    |  Yes  |   Yes   |
 |        [BCLaws](http://www.bclaws.ca/civix/template/complete/api/index.html)        | Access to the laws of British Columbia                                                    |    No    |  No   | Unknown |
 |                       [BuildData](https://builddata.ca)                             | Canadian construction and development data from 17 cities                                 | `apiKey` |  Yes  | Unknown |
 |         [Census.gov](https://www.census.gov/data/developers/data-sets.html)         | The US Census Bureau provides various APIs and data sets on demographics and businesses   |    No    |  Yes  | Unknown |


### PR DESCRIPTION
Adds Bargo Congress Trades to the Government section.\n\nThe API provides U.S. Congress STOCK Act stock trades with per-trade performance, supports HTTPS and CORS, and has keyless read endpoints.\n\nTested endpoints:\n- https://www.bargo.ai/free-apis/congress/v1/health\n- https://www.bargo.ai/free-apis/congress/v1/trades/NVDA?limit=2