### PR TITLE
Add Bargo Congress Trades API

### DIFF
--- a/README.md
+++ b/README.md
@@ -469,6 +469,7 @@
 | :----------------------------------------------------------------------: | ------------------------------------------------------------- | :------: | :---: | :-----: |
 |              [Alpha Vantage](https://www.alphavantage.co/)               | Realtime and historical stock data                            | `apiKey` |  Yes  | Unknown |
 |        [Barchart OnDemand](https://www.barchartondemand.com/free)        | Stock, Futures and Forex Market Data                          | `apiKey` |  Yes  | Unknown |
+|       [Bargo Congress Trades](https://www.bargo.ai/free-apis/congress)   | U.S. Congress STOCK Act stock trades with per-trade performance |    No    |  Yes  |   Yes   |
 |           [CommodityPriceAPI](https://commoditypriceapi.com/)            | Real-time & historical commodity prices (metals, energy, etc) | `apiKey` |  Yes  | Unknown |
 | [Congressional Stock Brain](https://congressionalstockbrain.com) | AI-powered tool scoring U.S. STOCK Act lawmaker trade disclosures for retail investors | No | Yes | Yes |
 |             [Earnings Feed](https://earningsfeed.com/api)                | Real-time SEC filings, insider trades, and institutional holdings | `apiKey` |  Yes  |   No    |


### PR DESCRIPTION
Adds Bargo Congress Trades API to the public API list.

Free tier limits from the docs:
- Keyless: 30 requests/day and 1,000 rows/day per IP
- Free API key: 1,000 requests/day and 25,000 rows/day

No credit card required.
