### PR TITLE
Add Doqlo API

### DIFF
--- a/README.md
+++ b/README.md
@@ -409,6 +409,7 @@
 | :-------------------------------------------------------------------------------: | -------------------------------------------------------------- | :------: | :---: | :-----: |
 | [Cloudmersive Document and Data Conversion](https://cloudmersive.com/convert-api) | HTML/URL to PDF/PNG, Office documents to PDF, image conversion | `apiKey` |  Yes  |   Yes   |
 |     [CustomJS](https://www.customjs.space/integration/pdf-api/html-to-pdf)        | HTML to PDF or PDF to PNG/Text & merging/extraction APIs       | `apiKey` |  Yes  | Unknown |
+|                          [Doqlo](https://doqlo.com)                               | Bulk fill and mail merge PDF forms from CSV                    | `apiKey` |  Yes  | Unknown |
 |                       [DynamicDocs](https://advicement.io)                        | Generate dynamic PDFs with JSON to PDF API based on LaTeX      | `apiKey` |  Yes  | Unknown |
 |                          [File.io](https://www.file.io)                           | File Sharing                                                   |    No    |  Yes  | Unknown |
 | [IDPhotoSnap Passport Photo Specs](https://idphotosnap.com/api/specs)             | Passport, visa, and ID photo specifications for 100+ countries with government source citations |    No    |  Yes  |   Yes   |


### PR DESCRIPTION
## Type of Change

* [x] Adding a new API entry
* [ ] Fixing a broken link
* [ ] Updating an existing entry
* [ ] Documentation / formatting fix
* [ ] Other (please describe):

## Checklist

* [x] Entry format: `| [Name](URL) | Description | Auth | HTTPS | CORS |`
* [x] Auth value is one of: `No`, `apiKey`, `OAuth`, `X-Mashape-Key`
* [x] HTTPS value is `Yes` or `No`
* [x] CORS value is `Yes`, `No`, or `Unknown`
* [x] Description does **not** end with punctuation
* [x] Entry is placed in **alphabetical order** within the correct section
* [x] Each table column is padded with one space on either side
* [x] I have **not removed** any existing entries
* [x] I have searched the list for duplicates (same API name or URL)
* [x] The API link is working and returns documentation
* [x] All changes have been [[squashed](https://github.com/todotxt/todo.txt-android/wiki/Squash-All-Commits-Related-to-a-Single-Issue-into-a-Single-Commit)][squash-link] into a single commit

## API Details

**API Name:** Doqlo

**Category/Section:** Documents & Productivity

**Why this API is useful:** Doqlo provides a Public API for bulk filling and mail merging PDF forms from CSV, helping developers automate PDF form workflows without manually filling each document.

[squash-link]: https://github.com/todotxt/todo.txt-android/wiki/Squash-All-Commits-Related-to-a-Single-Issue-into-a-Single-Commit