### PR TITLE
Add biz collect to Business

### DIFF
--- a/README.md
+++ b/README.md
@@ -142,6 +142,7 @@
 
 |                                    API                                     | Description                                                               |   Auth   | HTTPS |  CORS   |
 | :------------------------------------------------------------------------: | ------------------------------------------------------------------------- | :------: | :---: | :-----: |
+| [biz collect](https://bizcollect.dev) | Business contact data from a location and keywords, including emails | `apiKey` | Yes | Unknown |
 |             [Charity Search](http://charityapi.orghunter.com/)             | Non-profit charity data                                                   | `apiKey` |  No   | Unknown |
 |            [Clearbit Logo](https://clearbit.com/docs#logo-api)             | Search for company logos and embed them in your projects                  | `apiKey` |  Yes  | Unknown |
 |                    [Clientsbee](https://clientsbee.com)                    | Free leads for bussiness and technographics data                          | `apikey` |  Yes  |   No    |


### PR DESCRIPTION
## Type of Change

- [x] Adding a new API entry

## Checklist

- [x] Entry format: `| [Name](URL) | Description | Auth | HTTPS | CORS |`
- [x] Auth value is one of: `No`, `apiKey`, `OAuth`, `X-Mashape-Key`
- [x] HTTPS value is `Yes` or `No`
- [x] CORS value is `Yes`, `No`, or `Unknown`
- [x] Description does not end with punctuation
- [x] Entry is placed in alphabetical order within the correct section
- [x] Each table column is padded with one space on either side
- [x] I have not removed any existing entries
- [x] I have searched the list for duplicates (same API name or URL)
- [x] The API link is working and returns documentation
- [x] All changes have been squashed into a single commit

## API Details

**API Name:** biz collect
**Category/Section:** Business
**Why this API is useful:** Turns a location + keywords into structured local business data (contact info, hours, socials) including emails, similar in spirit to the existing Tomba Email finder entry in this section.

Disclosure: I'm the builder of biz collect. Auth is a bearer API key (`Authorization: Bearer biz_live_...`), listed as `apiKey` per your convention. It has a free tier (200 signup credits, no card required). Happy to adjust format or withdraw if it's not a fit.