### PR TITLE
Add Cambio Uruguay to Currency Exchange

### DIFF
--- a/README.md
+++ b/README.md
@@ -254,6 +254,7 @@
 | :----------------------------------------------------------------------------------------------------------: | ------------------------------------------------------------------ | :------: | :---: | :-----: |
 |                        [1Forge](https://1forge.com/forex-data-api/api-documentation)                         | Forex currency market data                                         | `apiKey` |  Yes  | Unknown |
 |                              [AllRatesToday](https://allratestoday.com)                                       | Real-time mid-market exchange rates for 160+ currencies with SDKs   | `apiKey` |  Yes  | Unknown |
+|                            [Cambio Uruguay](https://cambio-uruguay.com)                                       | Real-time buy/sell rates from every Uruguayan exchange house with conversion and history | No | Yes | Yes |
 |                              [Coinnect](https://coinnect.bot/docs)                                           | Open money transfer routing across fiat, crypto and P2P networks   | `apiKey` |  Yes  |   Yes   |
 |                                [CurrencyFreaks](https://currencyfreaks.com/)                                 | Currency conversion with latest & historical forex exchange rates  | `apiKey` |  Yes  | Unknown |
 |                           [Currencylayer](https://currencylayer.com/documentation)                           | Exchange rates and currency conversion                             | `apiKey` |  Yes  | Unknown |


### PR DESCRIPTION
Adds **Cambio Uruguay** to the **Currency Exchange** section.

| Field | Value |
|---|---|
| API | https://api.cambio-uruguay.com |
| Site | https://cambio-uruguay.com |
| Auth | No |
| HTTPS | Yes |
| CORS | Yes |

Free, no-auth REST API aggregating **real-time buy/sell exchange rates from every Uruguayan casa de cambio (exchange house)**, plus currency conversion and historical rate series. JSON responses.

- Single entry, single section
- Inserted in alphabetical order (between *AllRatesToday* and *Coinnect*)
- Passes `validate_pr.py` and `sort_entries.py` locally