### PR TITLE
Add Dino Markets API

### DIFF
--- a/README.md
+++ b/README.md
@@ -992,6 +992,7 @@
 |        [Cartola FC](https://github.com/wgenial/cartrolandofc)         | The Cartola FC API serves to check the partial points of your team                          |       No        |  Yes  | Unknown |
 |                [City Bikes](http://api.citybik.es/v2/)                | City Bikes around the world                                                                 |       No        |  No   | Unknown |
 |                 [CricData](https://cricketdata.org/)                  | Ultimate Cricket data API - Score, Scorecard, Players data, Fantasy API                     |    `apiKey`     |  Yes  | Unknown |
+|             [Dino Markets](https://dino.markets/docs)                 | Cross-venue sports prediction-market data: Kalshi and Polymarket matched, live arb, free tier |    `apiKey`     |  Yes  |   No    |
 |                [DiscGolf](https://discgolfapi.com/docs/)              | Structured disc golf course data                                                            |       No        |  Yes  |   Yes   |
 |                      [F1 API](https://f1api.dev)                      | Free F1 data in real time with his own NPM package                                          |       No        |  Yes  | Unknown |
 |        [F1 Data API](https://github.com/Jacobbrewer1/f1-data)         | Formula 1 data API that delivers data from the F1 Archive dating back to 1950               |       No        |  Yes  |   No    |


### PR DESCRIPTION
Adds Dino Markets to Sports & Fitness.

Real-time cross-venue sports prediction-market data — matches the same games across Kalshi and Polymarket, computes the live arbitrage between the two venues, and serves it over REST + WebSocket. Free tier included (60 req/min, no card).

- [x] Alphabetical order maintained (inserted between CricData and DiscGolf)
- [x] Description does not end with punctuation
- [x] One entry, one section
- [x] Auth/HTTPS/CORS verified against the live API