### PR TITLE
Add Rope Drop News API

### DIFF
--- a/README.md
+++ b/README.md
@@ -818,6 +818,7 @@
 | [OpenCorporates](http://api.opencorporates.com/documentation/API-Reference) | Data on corporate entities and directors in many countries                                         | `apiKey` |  Yes  | Unknown |
 |                      [Quandl](https://www.quandl.com/)                      | Stock Market Data                                                                                  |    No    |  Yes  | Unknown |
 |       [Recreation Information Database](https://ridb.recreation.gov/)       | Recreational areas, federal lands, historic sites, museums, and other attractions/resources(US)    | `apiKey` |  Yes  | Unknown |
+| [Rope Drop News](https://ropedropnews.com/developers) | Live Disney and Universal theme park wait times, ride reliability, crowds, and Lightning Lane prices | No | Yes | No |
 |                     [Scoop.it](http://www.scoop.it/dev)                     | Content Curation Service                                                                           | `apiKey` |  No   | Unknown |
 |    [Universities List](https://github.com/Hipo/university-domains-list)     | University names, countries and domains                                                            |    No    |  Yes  | Unknown |
 |                 [University of Oslo](https://data.uio.no/)                  | Courses, lecture videos, detailed information for courses etc. for the University of Oslo (Norway) |    No    |  Yes  | Unknown |


### PR DESCRIPTION
Adds Rope Drop News to the Open Data category.

Rope Drop News publishes free, first-party live theme-park data for Walt Disney World, Disneyland, and Universal Epic Universe: wait times, ride reliability, crowd levels, and Lightning Lane prices. Served as anonymous JSON feeds and CC BY 4.0 CSV datasets over HTTPS.

- Docs: https://ropedropnews.com/developers
- Auth: No, HTTPS: Yes, CORS: No
- Free and open, no API key.