### PR TITLE
Add localmodel.run to Open Data

### DIFF
--- a/README.md
+++ b/README.md
@@ -814,6 +814,7 @@
 |              [Fruits](https://fruits-api.netlify.app/graphql)               | Information of fruit trees of the world                                                            |    No    |  Yes  |   No    |
 | [Is It Safe to Travel](https://isitsafetotravel.org/en/api/) | Daily travel-safety scores and 5 risk pillars for 248 countries, from gov advisories and indices | No | Yes | Yes |
 |                 [LinkPreview](https://www.linkpreview.net)                  | Get JSON formatted summary with title, description and preview image for any requested URL         | `apiKey` |  Yes  |   Yes   |
+| [localmodel.run](https://localmodel.run/api/openapi.json) | Memory requirements for 153 local AI models across 40 devices, sourced, OpenAPI 3.1 spec | No | Yes | Yes |
 |                    [Microlink.io](https://microlink.io)                     | Extract structured data from any website                                                           |    No    |  Yes  |   Yes   |
 | [OpenCorporates](http://api.opencorporates.com/documentation/API-Reference) | Data on corporate entities and directors in many countries                                         | `apiKey` |  Yes  | Unknown |
 |                      [Quandl](https://www.quandl.com/)                      | Stock Market Data                                                                                  |    No    |  Yes  | Unknown |


### PR DESCRIPTION
Adds localmodel.run to Open Data, alphabetically between LinkPreview and Microlink.io.

Free, no-auth API: sourced memory requirements for 153 local AI models across 40 devices. OpenAPI 3.1 spec at the linked URL. CORS is open (access-control-allow-origin: *). Data is CC BY 4.0.

- [x] One entry, alphabetical order kept
- [x] Description under 100 characters, no trailing punctuation
- [x] Auth: No, HTTPS: Yes, CORS: Yes (verified against the live endpoint)

Disclosure: I am the author.