### PR TITLE
Add College ROI API

### DIFF
--- a/README.md
+++ b/README.md
@@ -439,6 +439,7 @@
 
 |                                        API                                         | Description                                                      |   Auth   | HTTPS |  CORS  |
 | :--------------------------------------------------------------------------------: | ---------------------------------------------------------------- | :------: | :---: | :----: |
+| [College ROI](https://le-teen.com/api) | Lifetime ROI of US colleges and majors — free static JSON, CC BY 4.0 | No | Yes | Yes |
 | [Current Affairs](https://rapidapi.com/malaithiru370/api/current-affairs-of-india) | Current International Affairs, quizzes and more                  | `apiKey` |  Yes  |   No   |
 |                    [NationNode](https://nationnode.vercel.app)                     | Used to fetch the specific details about a country               |    No    |  Yes  |  Yes   |
 |                 [Secrets-APi](https://secrets-api.appbrewery.com/)                 | Used For Learning purpose Learn all security types with this api |   `apiKey`    |  Yes  | Unknown |


### PR DESCRIPTION
Adds College ROI to Education: free, keyless, CORS-open static JSON API for the lifetime return on investment of US colleges and majors (30-year NPV per school, ROI statistics per major and subfield), computed from public FREOPP/IPEDS/BEA data. Docs: https://le-teen.com/api · OpenAPI 3.1 spec: https://le-teen.com/api/v1/openapi.json. Underlying dataset is open (CC BY 4.0, Zenodo DOI 10.5281/zenodo.21351603). Disclosure: I maintain this API.