### PR TITLE
Add MyPayslip.lk to Finance

### DIFF
--- a/README.md
+++ b/README.md
@@ -488,6 +488,7 @@
 | [Indian Bank Data API](https://github.com/kaustubhk24/Indian-Banks-Data) | All Banks IFSC Code data,Search by IFSc or other details      |    No    |  Yes  | Unknown |
 |        [KeepRule](https://github.com/henu-wang/keeprule-api)             | Investment principles and quotes from Buffett, Munger & more  |    No    |  Yes  |   Yes   |
 |                 [Mboum API](https://docs.mboum.com)                 | Real-time Stock market and Options Data                             | `apiKey` |  Yes  | Unknown |
+| [MyPayslip.lk](https://mypayslip.lk/openapi.json) | Sri Lanka APIT, EPF, ETF, stamp duty and net salary calculations | No | Yes | Yes |
 |                       [Plaid](https://plaid.com/)                        | Connect with users’ bank accounts and access transaction data | `apiKey` |  Yes  | Unknown |
 | [Polish Bank Branches](https://ksefekburczymucha.pl/api/bank/) | Polish bank branch lookup by 8-digit clearing number (Numer Rozliczeniowy) or full 26-digit IBAN, free, no API key | No | Yes | Yes |
 |                    [Polygon.io](https://polygon.io/docs/)                | Real-time and historical stock market data, crypto and forex  | `apiKey` |  Yes  |   Yes   |


### PR DESCRIPTION
## Type of Change

- [x] Adding a new API entry
- [ ] Fixing a broken link
- [ ] Updating an existing entry
- [ ] Documentation / formatting fix
- [ ] Other

## Checklist

- [x] Entry uses the required five-column format
- [x] Auth is `No`
- [x] HTTPS is `Yes`
- [x] CORS is `Yes`
- [x] Description has no trailing punctuation
- [x] Entry is alphabetized in Finance
- [x] No existing entries were removed
- [x] No duplicate name or URL exists
- [x] The linked OpenAPI documentation returns HTTP 200
- [x] The API endpoint returns HTTP 200 JSON without authentication
- [x] Local `.github/scripts/validate_pr.py` passes
- [x] The change is one commit

## API Details

**API Name:** MyPayslip.lk  
**Category/Section:** Finance  
**Why this API is useful:** It provides deterministic Sri Lankan APIT/PAYE, EPF, ETF, stamp-duty and net-salary calculations through a free read-only endpoint. The API has OpenAPI 3.1 documentation, wildcard CORS and a public tested reference implementation.