### PR TITLE
Add ProblemsByVin — free NHTSA vehicle owner-complaint & recall data

### DIFF
--- a/README.md
+++ b/README.md
@@ -1131,6 +1131,7 @@
 |     [Kelley Blue Book](http://developer.kbb.com/#!/data/1-Default)     | Vehicle info, pricing, configuration, plus much more                                             | `apiKey` |  Yes  |   No    |
 |       [Mercedes-Benz](https://developer.mercedes-benz.com/apis)        | Telematics data, remotely access vehicle functions, car configurator, locate service dealers     | `apiKey` |  Yes  |   No    |
 |                [NHTSA](https://vpic.nhtsa.dot.gov/api/)                | NHTSA Product Information Catalog and Vehicle Listing                                            |    No    |  Yes  | Unknown |
+| [ProblemsByVin](https://problemsbyvin.com/data/) | US NHTSA owner-complaint & recall data as vehicle failure patterns by year, make & model; open CSV/JSON datasets + a machine-readable catalog | No | Yes | Yes |
 |                 [Smartcar](https://smartcar.com/docs/)                 | Lock and unlock vehicles and get data like odometer reading and location. Works on most new cars | `OAuth`  |  Yes  |   Yes   |
 
 **[⬆ Back to Index](#index)**


### PR DESCRIPTION
Adds **ProblemsByVin** to the **Vehicle** category.

- **Link:** https://problemsbyvin.com/data/ (machine-readable catalog at https://problemsbyvin.com/data/catalog.json)
- **What it is:** open datasets derived from the US NHTSA owner-complaint & recall record — vehicle failure patterns, reliability scores, and failure-mileage by year/make/model, as CSV + JSON.
- **Auth:** No · **HTTPS:** Yes · **CORS:** Yes (verified `Access-Control-Allow-Origin: *` on the JSON endpoints)
- **License:** CC BY 4.0 (free, no signup).

Complements the existing vPIC `NHTSA` entry, which is the spec/product catalog — this is the owner-complaint & recall failure-pattern data, a different dataset. Entry inserted alphabetically.