### PR TITLE
Add ProteinBenchmark to Food & Drink

### DIFF
--- a/README.md
+++ b/README.md
@@ -510,6 +510,7 @@
 |                     [Edamam](https://developer.edamam.com/)                      | Recipe Search                                     | `apiKey` |  Yes  | Unknown |
 |                 [Open Brewery DB](https://www.openbrewerydb.org)                 | Breweries, Cideries and Craft Beer Bottle Shops   |    No    |  Yes  |   Yes   |
 |             [Open Food Facts](https://world.openfoodfacts.org/data)              | Food Products Database                            |    No    |  Yes  | Unknown |
+| [ProteinBenchmark](https://proteinbenchmark.com/api) | Protein content, density scores and DIAAS-adjusted metrics for ~200 foods and powders | No | Yes | Yes |
 |                   [PunkAPI](https://github.com/alxiw/punkapi)                    | BrewDog's DIY Dog beer catalogue as an API        |    No    |  Yes  |   Yes   |
 |                     [RecipeAPI](https://recipeapi.io)                             | Recipes, ingredients, nutrition and instructions  | `apiKey` |  Yes  |   Yes   |
 |                 [Spoonacular](https://spoonacular.com/food-api)                  | Food and Recipes                                  | `apiKey` |  Yes  | Unknown |


### PR DESCRIPTION
Adds ProteinBenchmark, a free read-only JSON API for the protein content and
protein-density scores of ~200 food products (snacks, powders, restaurant items).

- Auth: No (no key required)
- HTTPS: Yes
- CORS: Yes (Access-Control-Allow-Origin: *, verified)
- Docs: https://proteinbenchmark.com/api
- OpenAPI 3.1 spec: https://proteinbenchmark.com/openapi.yaml

Placed alphabetically in Food & Drink between Open Food Facts and PunkAPI.

🤖 Generated with [Claude Code](https://claude.com/claude-code)