### PR TITLE
Add Website & Web-App Cost Data to Open Data

### DIFF
--- a/README.md
+++ b/README.md
@@ -822,6 +822,7 @@
 |    [Universities List](https://github.com/Hipo/university-domains-list)     | University names, countries and domains                                                            |    No    |  Yes  | Unknown |
 |                 [University of Oslo](https://data.uio.no/)                  | Courses, lecture videos, detailed information for courses etc. for the University of Oslo (Norway) |    No    |  Yes  | Unknown |
 |                 [UPC database](https://upcdatabase.org/api)                 | More than 1.5 million barcode numbers from all around the world                                    | `apiKey` |  Yes  | Unknown |
+| [Website & Web-App Cost Data](https://projectcostestimator.com/api-docs) | Web-project cost benchmarks by platform across 6 markets (build, hosting, 3-year TCO, hourly rates), CC BY 4.0 | No | Yes | Yes |
 |         [Wikidata](https://www.wikidata.org/w/api.php?action=help)          | Collaboratively edited knowledge base operated by the Wikimedia Foundation                         | `OAuth`  |  Yes  | Unknown |
 |          [Wikipedia](https://www.mediawiki.org/wiki/API:Main_page)          | Mediawiki Encyclopedia                                                                             |    No    |  Yes  | Unknown |
 


### PR DESCRIPTION
## Type of Change

- [x] Adding a new API entry
- [ ] Fixing a broken link
- [ ] Updating an existing entry
- [ ] Documentation / formatting fix
- [ ] Other (please describe):

## Checklist

- [x] Entry format: `| [Name](URL) | Description | Auth | HTTPS | CORS |`
- [x] Auth value is one of: `No`, `apiKey`, `OAuth`, `X-Mashape-Key`
- [x] HTTPS value is `Yes` or `No`
- [x] CORS value is `Yes`, `No`, or `Unknown`
- [x] Description does **not** end with punctuation
- [x] Entry is placed in **alphabetical order** within the correct section
- [x] Each table column is padded with one space on either side
- [x] I have **not removed** any existing entries
- [x] I have searched the list for duplicates (same API name or URL)
- [x] The API link is working and returns documentation
- [x] All changes have been squashed into a single commit

## API Details

**API Name:** Website & Web-App Cost Data
**Category/Section:** Open Data
**Why this API is useful:** Free, no-auth JSON endpoint (`https://projectcostestimator.com/api/cost-data`) publishing web-project cost benchmarks — build cost, hosting and 3-year TCO by platform (WordPress, Shopify, WooCommerce, Magento, custom) across 6 geographic markets, plus hourly-rate ranges by region and seniority. Licensed CC BY 4.0 so anyone can reuse or cite it. Verified before submitting: HTTPS 200, `Access-Control-Allow-Origin: *`, no authentication. Disclosure: I built this dataset/API. Ran `sort_entries.py` — ordering passes.