### PR TITLE
Add AI Model Watch to Machine Learning

### DIFF
--- a/README.md
+++ b/README.md
@@ -745,6 +745,7 @@
 |                                        API                                        | Description                                             |   Auth   | HTTPS |  CORS   |
 | :-------------------------------------------------------------------------------: | ------------------------------------------------------- | :------: | :---: | :-----: |
 | [AI Engine](https://ai-engine.net/apis/all-in-one) | 36+ AI endpoints: OCR, face detection, background removal, object detection, NSFW moderation, face swap, image generation | `apiKey` | Yes | Yes |
+| [AI Model Watch](https://aimodelwatch.dev/api) | Daily-updated prices, context windows & deprecation/EOL dates for 190+ AI/LLM models, sourced from official provider docs | No | Yes | Yes |
 | [Cloudmersive](https://www.cloudmersive.com/image-recognition-and-processing-api) | Image captioning, face recognition, NSFW classification | `apiKey` |  Yes  |   Yes   |
 | [CrowdSorcerer](https://crowdsourcerer.rebaselabs.online/docs) | Web research, entity enrichment, document parsing, code execution, LLM generation, PII detection | `apiKey` |  Yes  |   Yes   |
 | [HOL Registry Broker](https://hol.org/docs/registry-broker/) | Search and verify AI agents & MCP servers | `apiKey` |  Yes  |   Yes   |


### PR DESCRIPTION
Adds **AI Model Watch** to the Machine Learning category.

- **API:** https://aimodelwatch.dev/api
- **What it is:** a free, daily-updated JSON API cataloguing prices, context windows, and lifecycle/deprecation (EOL) dates for 190+ AI/LLM models across all major providers (OpenAI, Anthropic, Google, Mistral, xAI, DeepSeek, Meta, …). Every row carries the official `source_url` it was read from.
- **Endpoints:** `/api/models.json` and `/api/deprecations.json`
- **Auth:** None (no key, no signup)
- **HTTPS:** Yes
- **CORS:** Yes (`Access-Control-Allow-Origin: *` — verified)

Entry placed alphabetically within Machine Learning; single-line addition, no reordering, dedupe-checked (not previously listed).
