### PR TITLE
Add Zornade Italian cadastral API to Government section

### DIFF
--- a/README.md
+++ b/README.md
@@ -699,6 +699,7 @@
 |               [State, New York State Opendata](https://data.ny.gov/)               | New York State Open Data                                                                  | `OAuth`  |  Yes  | Unknown |
 |                   [USAspending.gov](https://api.usaspending.gov/)                   | US federal spending data                                                                  |    No    |  Yes  | Unknown |
 | [Watercare IGC (NZ)](https://devstack.co.nz/calculators/watercare-icg) | Auckland water and wastewater Infrastructure Growth Charge calculations | No | Yes | Yes |
+| [Zornade](https://zornade.com/api-particelle-catastali) | Italian cadastral parcels enriched with hydrogeological risk, OMI valuations, demographics and land cover across 85M parcels | `apiKey` | Yes | Unknown |
 
 **[⬆ Back to Index](#index)**
 


### PR DESCRIPTION
Adds Zornade, a free API for Italian cadastral parcels enriched with hydrogeological risk, OMI real estate valuations, demographics and land cover data (85M+ parcels, 100% free tier at 1,000 req/hour). Placed alphabetically at the end of the Government section, matching the format of similar entries like PermisAPI and BuildData.