### PR TITLE
Add Indexed to Business

### DIFF
--- a/README.md
+++ b/README.md
@@ -150,6 +150,7 @@
 |              [Freelancer](https://developers.freelancer.com)               | Hire freelancers to get work done                                         | `OAuth`  |  Yes  | Unknown |
 |             [Gmail](https://developers.google.com/gmail/api/)              | Flexible, RESTful access to the user's inbox                              | `OAuth`  |  Yes  | Unknown |
 |        [Google Analytics](https://developers.google.com/analytics/)        | Collect, configure and analyze your data to reach the right audience      | `OAuth`  |  Yes  | Unknown |
+| [Indexed](https://indexed.vc/docs/api) | Startup funding rounds, investors, and company tech stacks for founders, sales, and GTM engineers | `apiKey` | Yes | No |
 |                       [LogoKit](https://logokit.com)                       | Logo API for brands, stocks, and cryptocurrencies                         | `apiKey` |  Yes  | Unknown |
 | [MailboxValidator](https://www.mailboxvalidator.com/api-single-validation) | Validate email address to improve deliverability                          | `apiKey` |  Yes  | Unknown |
 |                    [mailgun](https://www.mailgun.com/)                     | Email Service                                                             | `apiKey` |  Yes  | Unknown |


### PR DESCRIPTION
Adds Indexed to the **Business** category.

| Field | Value |
| --- | --- |
| API | Indexed |
| Description | Startup funding rounds, investors, and company tech stacks for founders, sales, and GTM engineers |
| Auth | `apiKey` |
| HTTPS | Yes |
| CORS | No |
| Link | https://indexed.vc/docs/api |

Placed under `### Business`, alphabetically between Google Analytics and LogoKit. Rebased on current `master`, single commit, `README.md` only.

Business seemed a better fit than Finance since the data is company records rather than markets, which puts it alongside Clientsbee, SCALA Score and biz collect.

**Free tier:** every plan gets an API key and no card is required. `GET /api/v1/industries` needs no authentication at all. A free key also covers company and investor search plus `/api/v1/usage`. Docs cover auth, rate limits, pagination and error codes, and there is an OpenAPI 3.1 spec at https://indexed.vc/openapi.yaml

**CORS is `No`.** Verified, no `Access-Control-Allow-Origin` header is returned, so the API is server side only.

Ran `.github/scripts/validate_pr.py` locally against this change: `All validation checks passed`.
