### PR TITLE
Add Lumify API

### DIFF
--- a/README.md
+++ b/README.md
@@ -1000,6 +1000,7 @@
 |      [Football Prediction](https://boggio-analytics.com/fp-api/)      | Predictions for upcoming football matches, odds, results and stats                          | `X-Mashape-Key` |  Yes  | Unknown |
 |      [Golf-Data](https://github.com/Jacobbrewer1/golf-data-docs)      | Golf data API with golf course, club and hole information                                   |       No        |  Yes  |   No    |
 |           [JCDecaux Bike](https://developer.jcdecaux.com/)            | JCDecaux's self-service bicycles                                                            |    `apiKey`     |  Yes  | Unknown |
+|                   [Lumify](https://lumify.ai/docs)                    |Real-time sports intelligence: scores, odds, betting splits & AI bet analysis across 8 sports|    `apiKey`     |  Yes  |   No    |
 | [NBA Stats](https://any-api.com/nba_com/nba_com/docs/API_Description) | Current and historical NBA Statistics                                                       |       No        |  Yes  | Unknown |
 |       [NHL Records and Stats](https://gitlab.com/dword4/nhlapi)       | NHL historical data and statistics                                                          |       No        |  Yes  | Unknown |
 |               [PropLine](https://prop-line.com)                | Real-time player-props betting odds with graded prop resolution across 13 books incl. Pinnacle |    `apiKey`     |  Yes  | Unknown |


### PR DESCRIPTION
Adds **Lumify** to the **Sports & Fitness** section (placed alphabetically).

- **What it is:** an agent-ready sports intelligence API — real-time schedules, live scores, odds, and public betting splits across MLB, NFL, NBA, NHL, NCAAF, NCAAB, tennis, and soccer.
- **Docs:** https://lumify.ai/docs
- **Auth:** `apiKey` (Bearer) — self-serve free tier (1,000 credits, no card required).
- **HTTPS:** Yes  ·  **CORS:** No

Column padding matched to the existing table.

Made with [Cursor](https://cursor.com)