### PR TITLE
Add Live Tennis API to Sports & Fitness

### DIFF
--- a/README.md
+++ b/README.md
@@ -1000,6 +1000,7 @@
 |      [Football Prediction](https://boggio-analytics.com/fp-api/)      | Predictions for upcoming football matches, odds, results and stats                          | `X-Mashape-Key` |  Yes  | Unknown |
 |      [Golf-Data](https://github.com/Jacobbrewer1/golf-data-docs)      | Golf data API with golf course, club and hole information                                   |       No        |  Yes  |   No    |
 |           [JCDecaux Bike](https://developer.jcdecaux.com/)            | JCDecaux's self-service bicycles                                                            |    `apiKey`     |  Yes  | Unknown |
+|             [Live Tennis API](https://livetennisapi.com)              | Live tennis scores, fixtures and player data                                                |    `apiKey`     |  Yes  |   Yes   |
 | [NBA Stats](https://any-api.com/nba_com/nba_com/docs/API_Description) | Current and historical NBA Statistics                                                       |       No        |  Yes  | Unknown |
 |       [NHL Records and Stats](https://gitlab.com/dword4/nhlapi)       | NHL historical data and statistics                                                          |       No        |  Yes  | Unknown |
 |               [PropLine](https://prop-line.com)                | Real-time player-props betting odds with graded prop resolution across 13 books incl. Pinnacle |    `apiKey`     |  Yes  | Unknown |


### PR DESCRIPTION
Adds Live Tennis API (https://livetennisapi.com) to Sports & Fitness. Disclosure: this is a vendor submission — I work on this API. It has a permanent free tier of 1,000 requests/day with no card required; the entry is listed on that basis.

## Type of Change

- [x] Adding a new API entry
- [ ] Fixing a broken link
- [ ] Updating an existing entry
- [ ] Documentation / formatting fix
- [ ] Other (please describe):

## Checklist

- [x] Entry format: `| [Name](URL) | Description | Auth | HTTPS | CORS |`
- [x] Auth value is one of: `No`, `apiKey`, `OAuth`, `X-Mashape-Key`
- [x] HTTPS value is `Yes` or `No`
- [x] CORS value is `Yes`, `No`, or `Unknown`
- [x] Description does **not** end with punctuation
- [x] Entry is placed in **alphabetical order** within the correct section
- [x] Each table column is padded with one space on either side
- [x] I have **not removed** any existing entries
- [x] I have searched the list for duplicates (same API name or URL)
- [x] The API link is working and returns documentation
- [x] All changes have been [squashed][squash-link] into a single commit

## API Details

**API Name:** Live Tennis API
**Category/Section:** Sports & Fitness
**Why this API is useful:** Real-time tennis scores, players and fixtures for ATP, WTA, Challenger and ITF, over REST and WebSocket; free tier of 1,000 requests/day (no card), HTTPS, CORS enabled (`Access-Control-Allow-Origin: *`), apiKey auth.

`python3 .github/scripts/sort_entries.py` and `.github/scripts/validate_pr.py` both pass locally on this diff.

[squash-link]: <https://github.com/todotxt/todo.txt-android/wiki/Squash-All-Commits-Related-to-a-Single-Issue-into-a-Single-Commit>
