### PR TITLE
Remove Conformi (service discontinued)

### DIFF
--- a/README.md
+++ b/README.md
@@ -808,7 +808,6 @@
 |                    [Callook.info](https://callook.info)                     | United States ham radio callsigns                                                                  |    No    |  Yes  | Unknown |
 |                         [CARTO](https://carto.com/)                         | Location Information Prediction                                                                    | `apiKey` |  Yes  | Unknown |
 |               [CivicFeed](https://developers.civicfeed.com/)                | News articles and public datasets                                                                  | `apiKey` |  Yes  | Unknown |
-| [Conformi](https://conformi.eu/api/v1/openapi.json) | EU legal research over the EUR-Lex corpus (DE/EN/FR) with verifiable CELEX citations; semantic search, knowledge reports, legal timelines for GDPR, AI Act, NIS2, DORA | `apiKey` |  Yes  | Unknown |
 |     [Enigma Public](http://docs.enigma.com/public/public_v20_api_about)     | Broadest collection of public data                                                                 | `apiKey` |  Yes  |   Yes   |
 |          [French Address Search](https://geo.api.gouv.fr/adresse)           | Address search via the French Government                                                           |    No    |  Yes  | Unknown |
 |              [Fruits](https://fruits-api.netlify.app/graphql)               | Information of fruit trees of the world                                                            |    No    |  Yes  |   No    |


### PR DESCRIPTION
conformi.eu has been shut down; the domain now redirects elsewhere and the API no longer exists. This removes the dead entry.