### PR TITLE
Add WealthVille to Cryptocurrency

### DIFF
--- a/README.md
+++ b/README.md
@@ -242,6 +242,7 @@
 | [Pharos API](https://pharos.watch/about/api/) | Stablecoin risk, peg, liquidity, safety score, blacklist, mint/burn, yield, and chain-health data | `apiKey` | Yes | Unknown |
 |              [Poloniex](https://api-docs.poloniex.com/spot)              | US based digital asset exchange                                                                                                    | `apiKey` |  Yes  | Unknown |
 |               [Sharpe](https://www.sharpe.ai/docs/free-api)              | Crypto derivatives, funding, arbitrage, narratives, listings, and news data                                                        |    No    |  Yes  | Unknown |
+|          [WealthVille](https://wealthville.net/developers)               | Liquidity pool scores and Enter/Hold/Exit verdicts for Solana and EVM chains                                                        |    No    |  Yes  |   Yes   |
 |       [WorldCoinIndex](https://www.worldcoinindex.com/apiservice)        | Cryptocurrencies Prices                                                                                                            | `apiKey` |  Yes  | Unknown |
 
 **[⬆ Back to Index](#index)**


### PR DESCRIPTION
Adds one row to `### Cryptocurrency`, alphabetically between `Sharpe` and `WorldCoinIndex`.

```
| [WealthVille](https://wealthville.net/developers) | Liquidity pool scores and Enter/Hold/Exit verdicts for Solana and EVM chains | No | Yes | Yes |
```

A keyless REST API returning a 0-100 score and an Enter/Hold/Exit verdict for DeFi liquidity pools — ~68,800 on Solana and 575 across Ethereum, Arbitrum, Base, Optimism, Polygon and BSC — plus a `/track-record` endpoint that publishes misses alongside hits.

Against the stated rules:

- **Alphabetical** — `Wea` sorts after `Sharpe` and before `Wor`.
- **No trailing punctuation** on the description.
- **One entry** in this PR.
- **Auth `No`** — no key needed. An optional free partner key raises the rate limit only.
- **CORS `Yes`** — verified against every public endpoint:
  ```
  $ curl -sD- -o/dev/null -H 'Origin: https://example.com' https://wealthville.net/api/v1/pools/top?limit=1
  access-control-allow-origin: *
  ```

`.github/scripts/validate_pr.py` reports **"All validation checks passed"** against this branch locally.

Disclosure: I maintain this project.