### PR TITLE
Add Mydentify public API

### DIFF
--- a/README.md
+++ b/README.md
@@ -156,6 +156,7 @@
 |                    [Mailjet](https://www.mailjet.com/)                     | Email Service                                                             | `apiKey` |  Yes  | Unknown |
 |                     [Markbase](https://markbase.co)                        | Search 14M+ USPTO trademarks with fuzzy search and autocomplete           |    No    |  Yes  |   Yes   |
 |                   [markerapi](http://www.markerapi.com/)                   | Trademark Search                                                          |    No    |  No   | Unknown |
+|          [Mydentify](https://mydentify.com/openapi.json)                   | Discover software by task through structured product directories and weekly leaderboards |    No    |  Yes  |   Yes   |
 |              [SCALA Score](https://score.get-scala.com)                    | Search 250M+ company records across 50+ countries with revenue, employees, and credit scores |    No    |  Yes  | Unknown |
 |                  [Tomba Email finder](https://tomba.io/)                   | Email Finder for B2B sales and email marketing                            | `apiKey` |  Yes  |   Yes   |
 |                  [Trello](https://developers.trello.com/)                  | Boards, lists and cards to help you organize and prioritize your projects | `OAuth`  |  Yes  | Unknown |


### PR DESCRIPTION
## Type of Change

- [x] Adding a new API entry
- [ ] Updating an existing API entry
- [ ] Removing a broken or deprecated API
- [ ] Fixing formatting or documentation

## API Details

**API Name:** Mydentify

**Category/Section:** Business

**Why this API is useful:** Mydentify exposes a free, no-key HTTPS API for discovering software by task through structured product directories and weekly leaderboards. Its OpenAPI 3.1 document is public, and the directory feed supports browser CORS.

I am Mydentify’s founder/authorized maintainer and am disclosing that relationship. This contribution adds one factual entry for a genuinely free public API.

## Checklist

- [x] I have read and followed the contribution guidelines
- [x] The API is publicly accessible
- [x] The description is concise and ends without punctuation
- [x] The entry is alphabetically placed in the section
- [x] The repository validation script passes