### PR TITLE
Add DomScan API

### DIFF
--- a/README.md
+++ b/README.md
@@ -926,6 +926,7 @@
 | [Blooms](https://blooms-production.up.railway.app/api)  | Distribute keys once for serverless applications | No |  Yes  | No |
 | [ClassiFinder](https://classifinder.ai) | Detect leaked secrets and prompt-injection in text and return redacted output | `apiKey` | Yes | Yes |
 | [CVE.report](https://cve.report/api) | CVE records with NVD KEV and EPSS enrichment | No | Yes | Yes |
+| [DomScan](https://domscan.net/docs) | Domain, DNS, WHOIS/RDAP, TLS, email, brand and web intelligence | `apiKey` | Yes | Yes |
 |                              [FishFish](https://fishfish.gg/)                               | A volunteer cybersecurity project focused on providing resources and services that improve safety across Discord                                                     |    No    |  Yes  | Unknown |
 | [HackMyIP](https://hackmyip.com/api) | IP geolocation, VPN and proxy detection, email breach checks, DNS, WHOIS, and reverse DNS lookups | No | Yes | Yes |
 |                     [HaveIBeenPwned](https://haveibeenpwned.com/API/v3)                     | Passwords which have previously been exposed in data breaches                                                                                                        | `apiKey` |  Yes  | Unknown |


### PR DESCRIPTION
## Type of Change

- [x] Adding a new API entry

## Checklist

- [x] Entry uses the required five-column format
- [x] Auth is `apiKey`
- [x] HTTPS is `Yes`
- [x] CORS is `Yes`
- [x] Description does not end with punctuation
- [x] Entry is alphabetically placed in Security
- [x] No existing entries were removed
- [x] I searched for duplicate names, URLs, issues, and PRs
- [x] The documentation link works
- [x] All changes are in one commit

## API Details

**API Name:** DomScan  
**Category/Section:** Security  
**Why this API is useful:** It combines domain, DNS, WHOIS/RDAP, TLS, email, brand, and web intelligence behind one documented API with a free monthly allowance.

Validation: the repository validation script passes; docs returned HTTP 200; CORS preflight returned `Access-Control-Allow-Origin: *`.