### PR TITLE
Add Lumify to Sports & Fitness

### DIFF
--- a/README.md
+++ b/README.md
@@ -1004,6 +1004,7 @@
 |      [Football Prediction](https://boggio-analytics.com/fp-api/)      | Predictions for upcoming football matches, odds, results and stats                          | `X-Mashape-Key` |  Yes  | Unknown |
 |      [Golf-Data](https://github.com/Jacobbrewer1/golf-data-docs)      | Golf data API with golf course, club and hole information                                   |       No        |  Yes  |   No    |
 |           [JCDecaux Bike](https://developer.jcdecaux.com/)            | JCDecaux's self-service bicycles                                                            |    `apiKey`     |  Yes  | Unknown |
+|                    [Lumify](https://lumify.ai/docs)                   | Sports schedules, live scores, odds, and public betting splits                              |    `apiKey`     |  Yes  |   No    |
 | [NBA Stats](https://any-api.com/nba_com/nba_com/docs/API_Description) | Current and historical NBA Statistics                                                       |       No        |  Yes  | Unknown |
 |       [NHL Records and Stats](https://gitlab.com/dword4/nhlapi)       | NHL historical data and statistics                                                          |       No        |  Yes  | Unknown |
 |               [PropLine](https://prop-line.com)                | Real-time player-props betting odds with graded prop resolution across 13 books incl. Pinnacle |    `apiKey`     |  Yes  | Unknown |


### PR DESCRIPTION
Thank you for taking the time to work on a Pull Request for this project!

> **Note**: This PR will be automatically validated. Please make sure all checks pass before requesting review.

## Type of Change

- [x] Adding a new API entry
- [ ] Fixing a broken link
- [ ] Updating an existing entry
- [ ] Documentation / formatting fix
- [ ] Other (please describe):

## Checklist

- [x] Entry format: `| [Name](URL) | Description | Auth | HTTPS | CORS |`
- [x] Auth value is one of: `No`, `apiKey`, `OAuth`, `X-Mashape-Key`
- [x] HTTPS value is `Yes` or `No`
- [x] CORS value is `Yes`, `No`, or `Unknown`
- [x] Description does **not** end with punctuation
- [x] Entry is placed in **alphabetical order** within the correct section
- [x] Each table column is padded with one space on either side
- [x] I have **not removed** any existing entries
- [x] I have searched the list for duplicates (same API name or URL)
- [x] The API link is working and returns documentation
- [x] All changes have been [squashed][squash-link] into a single commit

## API Details

**API Name:** Lumify
**Category/Section:** Sports & Fitness
**Why this API is useful:** Provides sports schedules, live scores, odds, and public betting splits for developers building sports applications

[squash-link]: <https://github.com/todotxt/todo.txt-android/wiki/Squash-All-Commits-Related-to-a-Single-Issue-into-a-Single-Commit>