### PR TITLE
Add Mailtrap to Business section

### DIFF
--- a/README.md
+++ b/README.md
@@ -145,6 +145,7 @@
 | [MailboxValidator](https://www.mailboxvalidator.com/api-single-validation) | Validate email address to improve deliverability                          | `apiKey` |  Yes  | Unknown |
 |                    [mailgun](https://www.mailgun.com/)                     | Email Service                                                             | `apiKey` |  Yes  | Unknown |
 |                    [Mailjet](https://www.mailjet.com/)                     | Email Service                                                             | `apiKey` |  Yes  | Unknown |
+|                     [Mailtrap](https://mailtrap.io)                        | Email API and SMTP for sending transactional and bulk emails, with 4,000 free emails/month | `apiKey` | Yes | Unknown |
 |                     [Markbase](https://markbase.co)                        | Search 14M+ USPTO trademarks with fuzzy search and autocomplete           |    No    |  Yes  |   Yes   |
 |                   [markerapi](http://www.markerapi.com/)                   | Trademark Search                                                          |    No    |  No   | Unknown |
 |          [Mydentify](https://mydentify.com/openapi.json)                   | Discover software by task through structured product directories and weekly leaderboards |    No    |  Yes  |   Yes   |


### PR DESCRIPTION
Adds Mailtrap under Business section alongside existing email service entries (Mailgun, Mailjet). Mailtrap provides Email API and SMTP for sending transactional and bulk emails with 4,000 free emails/month.

## Type of Change
- [x] Adding a new API entry

## Checklist
- [x] Entry format: `| [Name](URL) | Description | Auth | HTTPS | CORS |`
- [x] Auth value is one of: `No`, `apiKey`, `OAuth`, `X-Mashape-Key`
- [x] HTTPS value is `Yes` or `No`
- [x] CORS value is `Yes`, `No`, or `Unknown`
- [x] Description does **not** end with punctuation
- [x] Entry is placed in **alphabetical order** within the correct section
- [x] Each table column is padded with one space on either side
- [x] I have **not** removed any existing entries
- [x] I have searched the list for duplicates (same API name or URL)
- [x] The API link is working and returns documentation
- [x] All changes have been squashed into a single commit

## API Details
**API Name:** Mailtrap
**Category/Section:** Business
**Why this API is useful:** Email API and SMTP for sending transactional and bulk emails with a free tier of 4,000 emails/month