### PR TITLE
Add Veritify API to Data Validation

### DIFF
--- a/README.md
+++ b/README.md
@@ -283,6 +283,7 @@
 |                      [vatlayer](https://vatlayer.com)                       | VAT number validation                                                 |    No    |  Yes  | Unknown |
 |                   [VerifyEd](https://verifyed.org/docs)                    | Verify academic credentials — 912K+ schools, 2,592 diploma mills       | `apiKey` |  Yes  |   Yes   |
 |                      [Veriphone](https://veriphone.io)                      | Phone number validation & carrier lookup                              | `apiKey` |  Yes  |   Yes   |
+| [Veritify](https://github.com/PantaleonSystems/veritify-python/blob/main/docs/getting-started.md) | Verify data integrity and novelty in files with a public cryptographic receipt | `apiKey` | Yes | Yes |
 
 **[⬆ Back to Index](#index)**
 


### PR DESCRIPTION
Adds Veritify to the Data Validation section.

Veritify measures the integrity, novelty, and authenticity of arbitrary data (audio, text, documents) and returns a cryptographically verifiable receipt hash that anyone can independently confirm — no trust or API key required to verify. Self-service API key signup, free tier, documented Python SDK.

- Docs: https://github.com/PantaleonSystems/veritify-python/blob/main/docs/getting-started.md
- Live instance: https://veritify-api-production.up.railway.app/health

Ran `.github/scripts/sort_entries.py` (no ordering issues) and `.github/scripts/validate_pr.py` locally before opening this — both pass.