### PR TITLE
Add stillworks to Machine Learning

### DIFF
--- a/README.md
+++ b/README.md
@@ -754,6 +754,7 @@
 |                            [Keen IO](https://keen.io/)                            | Data Analytics                                          | `apiKey` |  Yes  | Unknown |
 |                  [Kiprio AI Content Detector](https://kiprio.com/ai-detect-api)                   | Detect AI-generated text with per-sentence confidence scoring         | `apiKey` |  Yes  |   Yes   |
 |                         [Replicate](https://replicate.com/docs/reference/http)    | Run and deploy machine learning models in the cloud     | `apiKey` |  Yes  |   Yes   |
+| [stillworks](https://stillworks.supercapybara.com) | Directories list. We check. Live-probed status of keyless LLM API endpoints, ranked by uptime | No | Yes | Yes |
 |                     [Unplugg](https://unplu.gg/test_api.html)                     | Forecasting API for timeseries data                     | `apiKey` |  Yes  | Unknown |
 |                             [Wit.ai](https://wit.ai/)                             | Natural Language Processing                             | `OAuth`  |  Yes  | Unknown |
 


### PR DESCRIPTION
## Type of Change

- [x] Adding a new API entry

## Checklist

- [x] Entry format: `| [Name](URL) | Description | Auth | HTTPS | CORS |`
- [x] Auth value is one of: `No`, `apiKey`, `OAuth`, `X-Mashape-Key`
- [x] HTTPS value is `Yes` or `No`
- [x] CORS value is `Yes`, `No`, or `Unknown`
- [x] Description does **not** end with punctuation
- [x] Entry is placed in **alphabetical order** within the correct section
- [x] Each table column is padded with one space on either side
- [x] I have **not removed** any existing entries
- [x] I have searched the list for duplicates (same API name or URL)
- [x] The API link is working and returns documentation
- [x] All changes have been squashed into a single commit

## API Details

**API Name:** stillworks

**Category/Section:** Machine Learning

**Why this API is useful:** `GET /api/llm/up` returns the LLM chat endpoints that are currently answering
with no `Authorization` header at all — base URL, model id, latency, and how much of the last week each one
answered — ranked, so `models[0]` is the pick and the rest are fallbacks. Every row was produced by a real
chat completion sent on a schedule, not by reading provider docs, and the failures are published next to the
successes. Capability flags (`tools`, `json_schema`, `json_object`, `vision`) are marked `proved` only when a
real call demonstrated them. Same shape as the existing AI Model Watch entry, but measured rather than sourced
from docs.

Verified for this entry: no auth, HTTPS, `Access-Control-Allow-Origin: *`.

Limits stated on the response itself: keyless quotas are commonly per-IP, so an endpoint verified from the
service's address can still refuse yours; rows probed with the project's own free-tier key prove only that the
endpoint answered that account.

```
curl -s https://stillworks.supercapybara.com/api/llm/up
```

Source: https://github.com/bon5co/stillworks (MIT)

Disclosure: I work on stillworks — this is a self-submission, not a third-party recommendation.
