### PR TITLE
Add Economic Calendar Pro to Finance

### DIFF
--- a/README.md
+++ b/README.md
@@ -479,6 +479,7 @@
 |           [CommodityPriceAPI](https://commoditypriceapi.com/)            | Real-time & historical commodity prices (metals, energy, etc) | `apiKey` |  Yes  | Unknown |
 | [Congressional Stock Brain](https://congressionalstockbrain.com) | AI-powered tool scoring U.S. STOCK Act lawmaker trade disclosures for retail investors | No | Yes | Yes |
 |             [Earnings Feed](https://earningsfeed.com/api)                | Real-time SEC filings, insider trades, and institutional holdings | `apiKey` |  Yes  |   No    |
+| [Economic Calendar Pro](https://apify.com/ichigowa/economic-calendar-pro) | ForexFactory economic calendar (FOMC/CPI/NFP) as JSON with currency and impact filters | `apiKey` | Yes | Yes |
 | [FilingFirehose](https://filingfirehose.com) | Structured SEC EDGAR filings with body-text-classified 8-Ks, activist-tagged 13D/G, and ATM-offering detection in S-3 / 424B5 | No | Yes | Yes |
 |               [Financial Data](https://financialdata.net/)               | Stock Market and Financial Data                               | `apiKey` |  Yes  | Unknown |
 |                 [IEX](https://iextrading.com/developer/)                 | Realtime stock data                                           | `apiKey` |  Yes  |   Yes   |


### PR DESCRIPTION
Adds [Economic Calendar Pro](https://apify.com/ichigowa/economic-calendar-pro) to the **Finance** section (inserted alphabetically).

ForexFactory economic calendar events (FOMC, CPI, NFP and more) as normalized JSON with currency and impact filters. HTTPS-only via api.apify.com, permissive CORS, `apiKey` auth (free Apify token).

Disclosure: I am the author/maintainer of this API (Apify actor), submitting my own project.

- [x] My submission is not a duplicate
- [x] Description is short, no trailing period
- [x] Row inserted alphabetically in the correct section
- [x] One API per pull request