### PR TITLE
Add Live Sports Scores to Sports & Fitness

### DIFF
--- a/README.md
+++ b/README.md
@@ -1004,6 +1004,7 @@
 |      [Football Prediction](https://boggio-analytics.com/fp-api/)      | Predictions for upcoming football matches, odds, results and stats                          | `X-Mashape-Key` |  Yes  | Unknown |
 |      [Golf-Data](https://github.com/Jacobbrewer1/golf-data-docs)      | Golf data API with golf course, club and hole information                                   |       No        |  Yes  |   No    |
 |           [JCDecaux Bike](https://developer.jcdecaux.com/)            | JCDecaux's self-service bicycles                                                            |    `apiKey`     |  Yes  | Unknown |
+| [Live Sports Scores](https://apify.com/ichigowa/live-sports-scores) | Live scores and schedules for NFL, NBA, MLB, NHL, EPL, MLS and NCAA as JSON | `apiKey` | Yes | Yes |
 | [NBA Stats](https://any-api.com/nba_com/nba_com/docs/API_Description) | Current and historical NBA Statistics                                                       |       No        |  Yes  | Unknown |
 |       [NHL Records and Stats](https://gitlab.com/dword4/nhlapi)       | NHL historical data and statistics                                                          |       No        |  Yes  | Unknown |
 |               [PropLine](https://prop-line.com)                | Real-time player-props betting odds with graded prop resolution across 13 books incl. Pinnacle |    `apiKey`     |  Yes  | Unknown |


### PR DESCRIPTION
Adds [Live Sports Scores](https://apify.com/ichigowa/live-sports-scores) to the **Sports & Fitness** section (inserted alphabetically).

Live scores, fixtures and final results for NFL, NBA, MLB, NHL, EPL, MLS and NCAA as normalized JSON. HTTPS-only via api.apify.com, permissive CORS, `apiKey` auth (free Apify token).

Disclosure: I am the author/maintainer of this API (Apify actor), submitting my own project.

- [x] My submission is not a duplicate
- [x] Description is short, no trailing period
- [x] Row inserted alphabetically in the correct section
- [x] One API per pull request