### PR TITLE
Add Publora to Social

### DIFF
--- a/README.md
+++ b/README.md
@@ -972,6 +972,7 @@
 | [Open Collective](https://docs.opencollective.com/help/developers/api) | Get Open Collective data                                                                          |    No    |  Yes  | Unknown |
 |             [Pinterest](https://developers.pinterest.com/)             | The world's catalog of ideas                                                                      | `OAuth`  |  Yes  | Unknown |
 |               [PWRTelegram bot](https://pwrtelegram.xyz)               | Boosted version of the Telegram bot API                                                           | `apiKey` |  Yes  | Unknown |
+|                [Publora](https://docs.publora.com)                     | Publish and schedule posts to ten social networks from one endpoint                               | `apiKey` |  Yes  |   No    |
 |                [Reddit](https://www.reddit.com/dev/api)                | Homepage of the internet                                                                          | `OAuth`  |  Yes  | Unknown |
 |                    [Slack](https://api.slack.com/)                     | Team Instant Messaging                                                                            | `OAuth`  |  Yes  | Unknown |
 |               [SocialData API](https://socialdata.tools)               | Unofficial API to read Twitter data                                                               | `apiKey` |  Yes  |   No    |


### PR DESCRIPTION
Adds Publora to **Social**.

| API | Description | Auth | HTTPS | CORS |
|---|---|---|---|---|
| [Publora](https://docs.publora.com) | Publish and schedule posts to ten social networks from one endpoint | `apiKey` | Yes | No |

One call publishes or schedules a post to LinkedIn, X, Instagram, Threads, TikTok, YouTube, Facebook, Bluesky, Mastodon and Telegram, with media upload and per-network options. The OpenAPI description is public at https://docs.publora.com/openapi.json

The free tier is 15 posts a month across three connected accounts, no card required. `CORS` is `No` because the API accepts browser requests only from our own domains; server-side use is unaffected.

Disclosure: I work on Publora.
