### PR TITLE
Add ERstat API

### DIFF
--- a/README.md
+++ b/README.md
@@ -709,6 +709,7 @@
 |                                      API                                      | Description                                                                                  |   Auth   | HTTPS |  CORS   |
 | :---------------------------------------------------------------------------: | -------------------------------------------------------------------------------------------- | :------: | :---: | :-----: |
 |                    [Diabetes](http://predictbgl.com/api/)                     | Logging and retrieving diabetes information                                                  |    No    |  No   | Unknown |
+| [ERstat](https://erstat.ca/developers) | Live Canadian emergency room closures and service disruptions, by province | `apiKey` | Yes | Yes |
 |           [Healthcare.gov](https://www.healthcare.gov/developers/)            | Educational content about the US Health Insurance Marketplace                                |    No    |  Yes  | Unknown |
 | [ICD-10 Codes](https://clinicaltables.nlm.nih.gov/apidoc/icd10cm/v3/doc.html) | List of all healthcare diagnosis codes                                                       |    No    |  Yes  | Unknown |
 |                 [Longevity World Cup](https://longevityworldcup.com/swagger)                 | Public biological age competition data with biomarkers and rankings                                |    No    |  Yes  |   Yes   |


### PR DESCRIPTION
Adds [ERstat](https://erstat.ca/developers) to **Health**.

- Live Canadian emergency room closures and service disruptions as JSON, plus per-province coverage of live wait-time reporting. Aggregated from official health-authority sources in every province.
- Free tier with a free API key (`X-API-Key`), non-commercial use with attribution. HTTPS yes, CORS yes.
- OpenAPI spec: https://erstat.ca/api/v1/openapi.json