### PR TITLE
Add GoldPrice88 to Finance APIs

### DIFF
--- a/README.md
+++ b/README.md
@@ -481,6 +481,7 @@
 |             [Earnings Feed](https://earningsfeed.com/api)                | Real-time SEC filings, insider trades, and institutional holdings | `apiKey` |  Yes  |   No    |
 | [FilingFirehose](https://filingfirehose.com) | Structured SEC EDGAR filings with body-text-classified 8-Ks, activist-tagged 13D/G, and ATM-offering detection in S-3 / 424B5 | No | Yes | Yes |
 |               [Financial Data](https://financialdata.net/)               | Stock Market and Financial Data                               | `apiKey` |  Yes  | Unknown |
+| [GoldPrice88](https://github.com/goldprice88-data/goldprice88-api) | Thai 96.5% gold prices with source, timestamps and stale-state metadata | No | Yes | Yes |
 |                 [IEX](https://iextrading.com/developer/)                 | Realtime stock data                                           | `apiKey` |  Yes  |   Yes   |
 |                 [IG](https://labs.ig.com/gettingstarted)                 | Spreadbetting and CFD Market Data                             | `apiKey` |  Yes  | Unknown |
 | [Indian Bank Data API](https://github.com/kaustubhk24/Indian-Banks-Data) | All Banks IFSC Code data,Search by IFSc or other details      |    No    |  Yes  | Unknown |


### PR DESCRIPTION
## Type of Change
- [x] Adding a new API entry
- [ ] Fixing a broken link
- [ ] Updating an existing entry
- [ ] Documentation / formatting fix
- [ ] Other

## Checklist
- [x] Entry format: `| [Name](URL) | Description | Auth | HTTPS | CORS |`
- [x] Auth value is one of: `No`, `apiKey`, `OAuth`, `X-Mashape-Key`
- [x] HTTPS value is `Yes` or `No`
- [x] CORS value is `Yes`, `No`, or `Unknown`
- [x] Description does not end with punctuation
- [x] Entry is placed in alphabetical order within the correct section
- [x] Each table column is padded with one space on either side
- [x] I have not removed any existing entries
- [x] I have searched the list for duplicates (same API name or URL)
- [x] The API link is working and returns documentation
- [x] All changes have been squashed into a single commit

## API Details
**API Name:** GoldPrice88

**Category/Section:** Finance

**Why this API is useful:** Provides free, no-auth Thai 96.5% gold prices with source, timestamps and stale-state metadata for developers. The HTTPS endpoint returned HTTP 200 during validation, and its CORS response allows cross-origin requests.

Validation notes:
- HTTPS endpoint returns HTTP 200
- No authentication required
- CORS: `Access-Control-Allow-Origin: *`
- Alphabetical placement after Financial Data
- No existing GoldPrice88 entry found