### PR TITLE
Add Filingrail API

### DIFF
--- a/README.md
+++ b/README.md
@@ -480,6 +480,7 @@
 | [Congressional Stock Brain](https://congressionalstockbrain.com) | AI-powered tool scoring U.S. STOCK Act lawmaker trade disclosures for retail investors | No | Yes | Yes |
 |             [Earnings Feed](https://earningsfeed.com/api)                | Real-time SEC filings, insider trades, and institutional holdings | `apiKey` |  Yes  |   No    |
 | [FilingFirehose](https://filingfirehose.com) | Structured SEC EDGAR filings with body-text-classified 8-Ks, activist-tagged 13D/G, and ATM-offering detection in S-3 / 424B5 | No | Yes | Yes |
+| [Filingrail](https://filingrail.hudsonenterprisesllc.com) | SEC EDGAR filings, XBRL financials, Form 4 insider trades, 8-K events and 13F holdings | `apiKey` | Yes | Unknown |
 |               [Financial Data](https://financialdata.net/)               | Stock Market and Financial Data                               | `apiKey` |  Yes  | Unknown |
 |                 [IEX](https://iextrading.com/developer/)                 | Realtime stock data                                           | `apiKey` |  Yes  |   Yes   |
 |                 [IG](https://labs.ig.com/gettingstarted)                 | Spreadbetting and CFD Market Data                             | `apiKey` |  Yes  | Unknown |


### PR DESCRIPTION
Adds Filingrail to **Finance**, alphabetically between FilingFirehose and Financial Data.

A REST API over SEC EDGAR: XBRL financials and history, Form 4 insider trades, 8-K material events with item codes, 13F institutional holdings, company search, and recent filings. Every record links back to the `sec.gov` filing it came from, so any figure can be verified against the original document.

- Free tier: 50 requests/day, no card required
- HTTPS: yes · Auth: `apiKey` · CORS: not documented for the gateway, so listed as `Unknown` rather than guessed
- Also ships a Python SDK and an MCP server listed on the official MCP registry

One entry, alphabetical order preserved, columns padded, single commit.