### PR TITLE
Add L2 Calendar API

### DIFF
--- a/README.md
+++ b/README.md
@@ -558,6 +558,7 @@
 |                   [JokeAPI](https://sv443.net/jokeapi/v2/)                    | Programming, Miscellaneous and Dark Jokes                                                                    |       No        |  Yes  |   Yes   |
 |             [Jokes](https://github.com/15Dkatz/official_joke_api)             | Programming and general jokes                                                                                |       No        |  Yes  | Unknown |
 |                   [Jokes One](https://jokes.one/api/joke/)                    | Joke of the day and large category of jokes accessible via REST API                                          |    `apiKey`     |  Yes  |   Yes   |
+| [L2 Calendar](https://l2calendar.com/api/servers?lang=en) | Lineage 2 private servers list with names, websites, chronicles, rates and opening dates | No | Yes | Yes |
 |                        [LotteryData.io](https://lotterydata.io/)              | Powerball, MegaMillions, and more results (live + historical) games                                          |    `apiKey`     |  Yes  |   Yes   |
 |              [Magic The Gathering](http://magicthegathering.io/)              | Magic The Gathering Game Information                                                                         |       No        |  No   | Unknown |
 |                     [Marvel](http://developer.marvel.com)                     | Marvel Comics                                                                                                |    `apiKey`     |  No   | Unknown |

--- a/README.md
+++ b/README.md
@@ -558,7 +558,7 @@
 |                   [JokeAPI](https://sv443.net/jokeapi/v2/)                    | Programming, Miscellaneous and Dark Jokes                                                                    |       No        |  Yes  |   Yes   |
 |             [Jokes](https://github.com/15Dkatz/official_joke_api)             | Programming and general jokes                                                                                |       No        |  Yes  | Unknown |
 |                   [Jokes One](https://jokes.one/api/joke/)                    | Joke of the day and large category of jokes accessible via REST API                                          |    `apiKey`     |  Yes  |   Yes   |
-| [L2 Calendar](https://l2calendar.com/api/servers?lang=en) | Lineage 2 private servers list with names, websites, chronicles, rates and opening dates | No | Yes | Yes |
+| [L2 Calendar](https://l2calendar.com/api/servers) | Lineage 2 private servers list with names, websites, chronicles, rates and opening dates | No | Yes | Yes |
 |                        [LotteryData.io](https://lotterydata.io/)              | Powerball, MegaMillions, and more results (live + historical) games                                          |    `apiKey`     |  Yes  |   Yes   |
 |              [Magic The Gathering](http://magicthegathering.io/)              | Magic The Gathering Game Information                                                                         |       No        |  No   | Unknown |
 |                     [Marvel](http://developer.marvel.com)                     | Marvel Comics                                                                                                |    `apiKey`     |  No   | Unknown |


### PR DESCRIPTION
## API Addition

**API Name:** L2 Calendar API
**Link:** https://l2calendar.com/api/servers
**Category:** Games & Comics

### Description
Public JSON API listing Lineage 2 private servers with names, websites, chronicles (Interlude, High Five, Classic, Essence...), rates and opening dates. Useful for game server trackers, community tools and L2 player dashboards.

### Checklist
- [x] Free access, no auth required
- [x] HTTPS supported
- [x] CORS enabled (Access-Control-Allow-Origin: *)
- [x] Data is public (same servers listed on the site homepage)
- [x] Inserted alphabetically (between Jokes One and LotteryData.io)

Verified live: 464 servers, application/json, stable endpoint.